### PR TITLE
Refactoring and unittests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
-*.pyc
-xcat.egg-info/
+# xcat
 .tmp/
+
+# Python
+*.pyc
+*.egg-info/
+
+# Virtual environment
 venv/
+
+# Unit test / coverage reports
+.tox/
+coverage/
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv/
 .tox/
 coverage/
 .coverage
+.cache

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+flake8
+pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist =
+  py3{5}
+
+[pytest]
+nonrecursedirs = .git .tox venv coverage
+
+[testenv]
+usedevelop = True
+deps =
+  -rrequirements.txt
+  -rrequirements-test.txt
+
+commands =
+  flake8 \
+    --ignore=E501,E266 \
+    --exclude test.py \
+    xcat
+  pytest \
+    -q \
+    --junitxml=coverage/unit.xml \
+    --cov xcat \
+    --cov-report xml:coverage/coverage.xml \
+    --cov-report html:coverage/html/ \
+    --cov-report term-missing \
+    {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 
 commands =
   flake8 \
-    --ignore=E501,E266 \
+    --ignore=E501,E266,W503 \
     --exclude test.py \
     xcat
   pytest \

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 
 import sys
-if sys.version_info.major < 3:
-    sys.stderr.write('Sorry, Python 3.x required by this example.\n')
-    sys.exit(1)
-
 import bitcoin
 import bitcoin.rpc
-from bitcoin import SelectParams
+# from bitcoin import SelectParams
 from bitcoin.core import b2x, lx, b2lx, x, COIN, COutPoint, CMutableTxOut, CMutableTxIn, CMutableTransaction, Hash160, CTransaction
 from bitcoin.base58 import decode
 from bitcoin.core.script import CScript, OP_DUP, OP_IF, OP_ELSE, OP_ENDIF, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG, SignatureHash, SIGHASH_ALL, OP_FALSE, OP_DROP, OP_CHECKLOCKTIMEVERIFY, OP_SHA256, OP_TRUE, OP_FALSE
@@ -17,17 +13,22 @@ from bitcoin.wallet import CBitcoinAddress, CBitcoinSecret, P2SHBitcoinAddress, 
 from xcat.utils import *
 import logging
 
+if sys.version_info.major < 3:
+    sys.stderr.write('Sorry, Python 3.x required by this example.\n')
+    sys.exit(1)
+
 FEE = 0.001*COIN
+
 
 class bitcoinProxy():
     def __init__(self, network='regtest', timeout=900):
         if network is not 'testnet' and network is not 'mainnet':
-            network='regtest'
+            network = 'regtest'
         logging.debug("NETWORK in proxy: {0}".format(network))
         self.network = network
         self.timeout = timeout
 
-        SelectParams(self.network)
+        bitcoin.SelectParams(self.network)
         self.bitcoind = bitcoin.rpc.Proxy(timeout=self.timeout)
 
     def validateaddress(self, addr):
@@ -41,9 +42,9 @@ class bitcoinProxy():
             print("TXINFO", decoded['vin'][0])
             if('txid' in decoded['vin'][0]):
                 sendid = decoded['vin'][0]['txid']
-                if (sendid == fundtx_input ):
+                if (sendid == fundtx_input):
                     print("Found funding tx: ", sendid)
-                    return parse_secret(lx(tx['txid']))
+                    return self.parse_secret(lx(tx['txid']))
         print("Redeem transaction with secret not found")
         return
 

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -21,7 +21,7 @@ if sys.version_info.major < 3:
     sys.stderr.write('Sorry, Python 3.x required by this example.\n')
     sys.exit(1)
 
-FEE = 0.001*COIN
+FEE = 0.001 * COIN
 
 
 class bitcoinProxy():
@@ -117,13 +117,13 @@ class bitcoinProxy():
         self.bitcoind.importaddress(p2sh, "", False)
         # Get amount in address
         amount = self.bitcoind.getreceivedbyaddress(p2sh, 0)
-        amount = amount/COIN
+        amount = amount / COIN
         return amount
 
     def get_fund_status(self, p2sh):
         self.bitcoind.importaddress(p2sh, "", False)
         amount = self.bitcoind.getreceivedbyaddress(p2sh, 0)
-        amount = amount/COIN
+        amount = amount / COIN
         print("Amount in bitcoin p2sh: ", amount, p2sh)
         if amount > 0:
             return 'funded'

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -14,7 +14,7 @@ from bitcoin.core.scripteval import VerifyScript, SCRIPT_VERIFY_P2SH
 from bitcoin.wallet import CBitcoinAddress, P2SHBitcoinAddress
 from bitcoin.wallet import P2PKHBitcoinAddress
 
-import xcat.utils as utils
+# import xcat.utils as utils
 import logging
 
 if sys.version_info.major < 3:
@@ -52,15 +52,15 @@ class bitcoinProxy():
         print("Redeem transaction with secret not found")
         return
 
-    def parse_secret(self, txid):
-        raw = zcashd.gettransaction(txid, True)['hex']
-        decoded = zcashd.call('decoderawtransaction', raw)
-        scriptSig = decoded['vin'][0]['scriptSig']
-        asm = scriptSig['asm'].split(" ")
-        # pubkey = asm[1]
-        secret = utils.x2s(asm[2])
-        # redeemPubkey = P2PKHBitcoinAddress.from_pubkey(x(pubkey))
-        return secret
+    # def parse_secret(self, txid):
+    #     raw = zcashd.gettransaction(txid, True)['hex']
+    #     decoded = zcashd.call('decoderawtransaction', raw)
+    #     scriptSig = decoded['vin'][0]['scriptSig']
+    #     asm = scriptSig['asm'].split(" ")
+    #     # pubkey = asm[1]
+    #     secret = utils.x2s(asm[2])
+    #     # redeemPubkey = P2PKHBitcoinAddress.from_pubkey(x(pubkey))
+    #     return secret
 
     def get_keys(self, funder_address, redeemer_address):
         fundpubkey = CBitcoinAddress(funder_address)
@@ -131,27 +131,27 @@ class bitcoinProxy():
             return 'empty'
 
     # TODO: FIX search for p2sh in block
-    def search_p2sh(self, block, p2sh):
-        print("Fetching block...")
-        blockdata = self.bitcoind.getblock(lx(block))
-        print("done fetching block")
-        txs = blockdata.vtx
-        print("txs", txs)
-        for tx in txs:
-            txhex = b2x(tx.serialize())
-            # Using my fork of python-zcashlib to get result of decoderawtransaction
-            txhex = txhex + '00'
-            rawtx = zcashd.decoderawtransaction(txhex)
-            # print('rawtx', rawtx)
-            print(rawtx)
-            for vout in rawtx['vout']:
-                if 'addresses' in vout['scriptPubKey']:
-                    for addr in vout['scriptPubKey']['addresses']:
-                        print("Sent to address:", addr)
-                        if addr == p2sh:
-                            print("Address to p2sh found in transaction! ",
-                                  addr)
-        print("Returning from search_p2sh")
+    # def search_p2sh(self, block, p2sh):
+    #     print("Fetching block...")
+    #     blockdata = self.bitcoind.getblock(lx(block))
+    #     print("done fetching block")
+    #     txs = blockdata.vtx
+    #     print("txs", txs)
+    #     for tx in txs:
+    #         txhex = b2x(tx.serialize())
+    #         # Using my fork of python-zcashlib to get result of decoderawtransaction
+    #         txhex = txhex + '00'
+    #         rawtx = zcashd.decoderawtransaction(txhex)
+    #         # print('rawtx', rawtx)
+    #         print(rawtx)
+    #         for vout in rawtx['vout']:
+    #             if 'addresses' in vout['scriptPubKey']:
+    #                 for addr in vout['scriptPubKey']['addresses']:
+    #                     print("Sent to address:", addr)
+    #                     if addr == p2sh:
+    #                         print("Address to p2sh found in transaction! ",
+    #                               addr)
+    #     print("Returning from search_p2sh")
 
     def get_tx_details(self, txid):
         # must convert txid string to bytes x(txid)

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -4,7 +4,6 @@ import sys
 import bitcoin
 import bitcoin.rpc
 from xcat.utils import x2s
-# from bitcoin import SelectParams
 from bitcoin.core import b2x, lx, x, COIN, CMutableTxOut
 from bitcoin.core import CMutableTxIn, CMutableTransaction
 from bitcoin.core.script import CScript, OP_DUP, OP_IF, OP_ELSE, OP_ENDIF
@@ -14,8 +13,6 @@ from bitcoin.core.script import OP_CHECKLOCKTIMEVERIFY, OP_SHA256, OP_TRUE
 from bitcoin.core.scripteval import VerifyScript, SCRIPT_VERIFY_P2SH
 from bitcoin.wallet import CBitcoinAddress, P2SHBitcoinAddress
 from bitcoin.wallet import P2PKHBitcoinAddress
-
-# import xcat.utils as utils
 import logging
 
 if sys.version_info.major < 3:
@@ -27,9 +24,13 @@ FEE = 0.001 * COIN
 
 class bitcoinProxy():
     def __init__(self, network='regtest', timeout=900):
-        if network is not 'testnet' and network is not 'mainnet':
-            network = 'regtest'
+        if network not in ['testnet', 'mainnet', 'regtest']:
+            raise ValueError('Allowed networks are regtest, testnet, mainnet.')
+        if not isinstance(timeout, int) or timeout < 1:
+            raise ValueError('Timeout should be a positive integer.')
+
         logging.debug("NETWORK in proxy: {0}".format(network))
+
         self.network = network
         self.timeout = timeout
 

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -3,6 +3,7 @@
 import sys
 import bitcoin
 import bitcoin.rpc
+from xcat.utils import x2s
 # from bitcoin import SelectParams
 from bitcoin.core import b2x, lx, x, COIN, CMutableTxOut
 from bitcoin.core import CMutableTxIn, CMutableTransaction
@@ -52,15 +53,15 @@ class bitcoinProxy():
         print("Redeem transaction with secret not found")
         return
 
-    # def parse_secret(self, txid):
-    #     raw = self.bitcoind.call('gettransaction', txid, True)['hex']
-    #     decoded = self.bitcoind.call('decoderawtransaction', raw)
-    #     scriptSig = decoded['vin'][0]['scriptSig']
-    #     asm = scriptSig['asm'].split(" ")
-    #     pubkey = asm[1]
-    #     secret = utils.x2s(asm[2])
-    #     redeemPubkey = P2PKHBitcoinAddress.from_pubkey(x(pubkey))
-    #     return secret
+    def parse_secret(self, txid):
+        raw = self.bitcoind.call('gettransaction', txid, True)['hex']
+        decoded = self.bitcoind.call('decoderawtransaction', raw)
+        scriptSig = decoded['vin'][0]['scriptSig']
+        asm = scriptSig['asm'].split(" ")
+        # pubkey = asm[1]
+        secret = x2s(asm[2])
+        # redeemPubkey = P2PKHBitcoinAddress.from_pubkey(x(pubkey))
+        return secret
 
     def get_keys(self, funder_address, redeemer_address):
         fundpubkey = CBitcoinAddress(funder_address)

--- a/xcat/bitcoinRPC.py
+++ b/xcat/bitcoinRPC.py
@@ -82,11 +82,11 @@ class bitcoinProxy():
         print("Current blocknum on Bitcoin: ", blocknum)
         redeemblocknum = blocknum + locktime
         print("Redeemblocknum on Bitcoin: ", redeemblocknum)
-        redeemScript = CScript(
-            [OP_IF, OP_SHA256, commitment, OP_EQUALVERIFY, OP_DUP, OP_HASH160,
-             redeemerAddr, OP_ELSE, redeemblocknum, OP_CHECKLOCKTIMEVERIFY,
-             OP_DROP, OP_DUP, OP_HASH160, funderAddr, OP_ENDIF, OP_EQUALVERIFY,
-             OP_CHECKSIG])
+        redeemScript = CScript([
+            OP_IF, OP_SHA256, commitment, OP_EQUALVERIFY, OP_DUP, OP_HASH160,
+            redeemerAddr, OP_ELSE, redeemblocknum, OP_CHECKLOCKTIMEVERIFY,
+            OP_DROP, OP_DUP, OP_HASH160, funderAddr, OP_ENDIF, OP_EQUALVERIFY,
+            OP_CHECKSIG])
         # print("Redeem script for p2sh contract on Bitcoin blockchain: "
         #        "{0}".format(b2x(redeemScript)))
         txin_scriptPubKey = redeemScript.to_p2sh_scriptPubKey()

--- a/xcat/cli.py
+++ b/xcat/cli.py
@@ -14,6 +14,7 @@ def save_state(trade, tradeid):
 
 
 def checkSellStatus(tradeid):
+    protocol = Protocol()
     trade = db.get(tradeid)
     status = seller_check_status(trade)
     print("Trade status: {0}\n".format(status))
@@ -25,7 +26,8 @@ def checkSellStatus(tradeid):
         save_state(trade, tradeid)
     elif status == 'buyerFunded':
         secret = db.get_secret(tradeid)
-        print("Retrieved secret to redeem funds for {0}: {1}".format(tradeid, secret))
+        print("Retrieved secret to redeem funds for "
+              "{0}: {1}".format(tradeid, secret))
         txs = protocol.seller_redeem_p2sh(trade, secret)
         if 'redeem_tx' in txs:
             trade.buy.redeem_tx = txs['redeem_tx']
@@ -43,6 +45,7 @@ def checkSellStatus(tradeid):
 
 
 def buyer_check_status(trade):
+    protocol = Protocol()
     sellState = protocol.check_fund_status(trade.sell.currency, trade.sell.p2sh)
     buyState = protocol.check_fund_status(trade.buy.currency, trade.buy.p2sh)
     if sellState == 'funded' and buyState == 'empty':
@@ -60,6 +63,7 @@ def buyer_check_status(trade):
 
 
 def seller_check_status(trade):
+    protocol = Protocol()
     sellState = protocol.check_fund_status(trade.sell.currency, trade.sell.p2sh)
     buyState = protocol.check_fund_status(trade.buy.currency, trade.buy.p2sh)
     if sellState == 'funded' and buyState == 'empty':
@@ -77,6 +81,7 @@ def seller_check_status(trade):
 
 
 def checkBuyStatus(tradeid):
+    protocol = Protocol()
     trade = db.get(tradeid)
     status = buyer_check_status(trade)
     print("Trade status: {0}\n".format(status))
@@ -114,6 +119,7 @@ def checkBuyStatus(tradeid):
 
 # Import a trade in hex, and save to db
 def importtrade(tradeid, hexstr=''):
+    protocol = Protocol()
     trade = x2s(hexstr)
     trade = db.instantiate(trade)
     protocol.import_addrs(trade)
@@ -157,6 +163,7 @@ def findtrade(tradeid):
 
 
 def find_role(contract):
+    protocol = Protocol()
     # When regtest created both addrs on same machine, role is both.
     if protocol.is_myaddr(contract.initiator):
         if protocol.is_myaddr(contract.fulfiller):
@@ -187,6 +194,7 @@ def checktrade(tradeid):
 
 
 def newtrade(tradeid, **kwargs):
+    protocol = Protocol()
     print("Creating new XCAT trade...")
     erase_trade()
     tradeid, trade = protocol.initialize_trade(tradeid, conf=kwargs['conf'])

--- a/xcat/cli.py
+++ b/xcat/cli.py
@@ -3,22 +3,26 @@ import textwrap
 import subprocess
 import os
 import logging
-import xcat.db as db
+from xcat.db import DB
 import xcat.userInput as userInput
 import xcat.utils as utils
 from xcat.protocol import Protocol
 
 
 def save_state(trade, tradeid):
+    db = DB()
     utils.save(trade)
     db.create(trade, tradeid)
 
 
 def checkSellStatus(tradeid):
+    db = DB()
     protocol = Protocol()
+
     trade = db.get(tradeid)
     status = seller_check_status(trade)
     print("Trade status: {0}\n".format(status))
+
     if status == 'init':
         userInput.authorize_fund_sell(trade)
         fund_tx = protocol.fund_sell_contract(trade)
@@ -91,6 +95,7 @@ def seller_check_status(trade):
 
 
 def checkBuyStatus(tradeid):
+    db = DB()
     protocol = Protocol()
     trade = db.get(tradeid)
     status = buyer_check_status(trade)
@@ -132,6 +137,7 @@ def checkBuyStatus(tradeid):
 
 # Import a trade in hex, and save to db
 def importtrade(tradeid, hexstr=''):
+    db = DB()
     protocol = Protocol()
     trade = utils.x2s(hexstr)
     trade = db.instantiate(trade)
@@ -156,6 +162,7 @@ def wormhole_importtrade():
 
 # Export a trade by its tradeid
 def exporttrade(tradeid, wormhole=False):
+    db = DB()
     trade = db.get(tradeid)
     hexstr = utils.s2x(trade.toJSON())
     if wormhole:
@@ -171,6 +178,7 @@ def exporttrade(tradeid, wormhole=False):
 
 
 def findtrade(tradeid):
+    db = DB()
     trade = db.get(tradeid)
     print(trade.toJSON())
     return trade
@@ -192,6 +200,7 @@ def find_role(contract):
 
 
 def checktrade(tradeid):
+    db = DB()
     print("In checktrade")
     trade = db.get(tradeid)
     if find_role(trade.sell) == 'test':
@@ -234,6 +243,7 @@ def newtrade(tradeid, **kwargs):
 
 
 def listtrades():
+    db = DB()
     print("Trades")
     trade_list = db.dump()
     for trade in trade_list:

--- a/xcat/cli.py
+++ b/xcat/cli.py
@@ -181,7 +181,10 @@ def find_role(contract):
         else:
             return 'initiator'
     else:
-        return 'fulfiller'
+        if protocol.is_myaddr(contract.fulfiller):
+            return 'fulfiller'
+        else:
+            raise ValueError('You are not a participant in this contract.')
 
 
 def checktrade(tradeid):

--- a/xcat/cli.py
+++ b/xcat/cli.py
@@ -215,14 +215,20 @@ def newtrade(tradeid, **kwargs):
     protocol = Protocol()
     print("Creating new XCAT trade...")
     utils.erase_trade()
+
+    conf = kwargs['conf'] if 'conf' in kwargs else 'regtest'
+    network = kwargs['network'] if 'network' in kwargs else 'regtest'
+
     tradeid, trade = protocol.initialize_trade(
         tradeid,
-        conf=kwargs['conf'],
-        network=kwargs['network'])
+        conf=conf,
+        network=network)
     print("New trade created: {0}".format(trade))
-    trade = protocol.seller_init(tradeid, trade, network=kwargs['network'])
+
+    trade = protocol.seller_init(tradeid, trade, network=network)
     print("\nUse 'xcat exporttrade [tradeid]' to export the trade and sent "
           "to the buyer.\n")
+
     save_state(trade, tradeid)
     return trade
 

--- a/xcat/db.py
+++ b/xcat/db.py
@@ -36,7 +36,8 @@ class DB():
         trade = self.instantiate(tradestr)
         return trade
 
-    def instantiate(self, trade):
+    @staticmethod
+    def instantiate(trade):
         if type(trade) == str:
             tradestr = json.loads(trade)
             trade = Trade(

--- a/xcat/db.py
+++ b/xcat/db.py
@@ -3,82 +3,78 @@ import json
 import xcat.utils as utils
 from xcat.trades import Trade, Contract
 
-db = plyvel.DB('/tmp/xcatDB', create_if_missing=True)
-preimageDB = plyvel.DB('/tmp/preimageDB', create_if_missing=True)
 
-#############################################
-######## Trades stored by tradeid ###########
-#############################################
+class DB():
 
+    def __init__(self):
+        self.db = plyvel.DB('/tmp/xcatDB', create_if_missing=True)
+        self.preimageDB = plyvel.DB('/tmp/preimageDB', create_if_missing=True)
 
-# Takes dict or obj, saves json str as bytes
-def create(trade, tradeid):
-    if type(trade) == dict:
-        trade = json.dumps(trade)
-    else:
+    #############################################
+    ######## Trades stored by tradeid ###########
+    #############################################
+
+    # Takes dict or obj, saves json str as bytes
+    def create(self, trade, tradeid):
+        if type(trade) == dict:
+            trade = json.dumps(trade)
+        else:
+            trade = trade.toJSON()
+        self.db.put(utils.b(tradeid), utils.b(trade))
+
+    #  Uses the funding txid as the key to save trade
+    def createByFundtx(self, trade):
         trade = trade.toJSON()
-    db.put(utils.b(tradeid), utils.b(trade))
+        # # Save trade by initiating txid
+        jt = json.loads(trade)
+        txid = jt['sell']['fund_tx']
+        self.db.put(utils.b(txid), utils.b(trade))
 
-
-#  Uses the funding txid as the key to save trade
-def createByFundtx(trade):
-    trade = trade.toJSON()
-    # # Save trade by initiating txid
-    jt = json.loads(trade)
-    txid = jt['sell']['fund_tx']
-    db.put(utils.b(txid), utils.b(trade))
-
-
-def get(tradeid):
-    rawtrade = db.get(utils.b(tradeid))
-    tradestr = str(rawtrade, 'utf-8')
-    trade = instantiate(tradestr)
-    return trade
-
-
-def instantiate(trade):
-    if type(trade) == str:
-        tradestr = json.loads(trade)
-        trade = Trade(
-            buy=Contract(tradestr['buy']),
-            sell=Contract(tradestr['sell']),
-            commitment=tradestr['commitment'])
+    def get(self, tradeid):
+        rawtrade = self.db.get(utils.b(tradeid))
+        tradestr = str(rawtrade, 'utf-8')
+        trade = self.instantiate(tradestr)
         return trade
 
-#############################################
-###### Preimages stored by tradeid ##########
-#############################################
+    def instantiate(self, trade):
+        if type(trade) == str:
+            tradestr = json.loads(trade)
+            trade = Trade(
+                buy=Contract(tradestr['buy']),
+                sell=Contract(tradestr['sell']),
+                commitment=tradestr['commitment'])
+            return trade
 
+    #############################################
+    ###### Preimages stored by tradeid ##########
+    #############################################
 
-# Stores secret locally in key/value store by tradeid
-def save_secret(tradeid, secret):
-    preimageDB.put(utils.b(tradeid), utils.b(secret))
+    # Stores secret locally in key/value store by tradeid
+    def save_secret(self, tradeid, secret):
+        self.preimageDB.put(utils.b(tradeid), utils.b(secret))
 
+    def get_secret(self, tradeid):
+        secret = self.preimageDB.get(utils.b(tradeid))
+        secret = str(secret, 'utf-8')
+        return secret
 
-def get_secret(tradeid):
-    secret = preimageDB.get(utils.b(tradeid))
-    secret = str(secret, 'utf-8')
-    return secret
+    #############################################
+    ########## Dump or view db entries ##########
+    #############################################
 
+    def dump(self):
+        results = []
+        with self.db.iterator() as it:
+            for k, v in it:
+                j = json.loads(utils.x2s(utils.b2x(v)))
+                results.append((str(k, 'utf-8'), j))
+        return results
 
-#############################################
-########## Dump or view db entries ##########
-#############################################
-
-def dump():
-    results = []
-    with db.iterator() as it:
-        for k, v in it:
-            j = json.loads(utils.x2s(utils.b2x(v)))
-            results.append((str(k, 'utf-8'), j))
-    return results
-
-
-def print_entries():
-    it = db.iterator()
-    with db.iterator() as it:
-        for k, v in it:
-            j = json.loads(utils.x2s(utils.b2x(v)))
-            print("Key:", k)
-            print('val: ', j)
-            # print('sell: ', j['sell'])
+    def print_entries(self):
+        it = self.db.iterator()
+        with self.db.iterator() as it:
+            for k, v in it:
+                j = json.loads(utils.x2s(utils.b2x(v)))
+                print("Key:", k)
+                print('val: ', j)
+                # print('sell: ', j['sell'])

--- a/xcat/db.py
+++ b/xcat/db.py
@@ -1,10 +1,10 @@
 import plyvel
-from xcat.utils import *
-import binascii
-import sys
 import json
-import ast
+# import binascii
+# import sys
+# import ast
 from xcat.trades import *
+from xcat.utils import *
 
 db = plyvel.DB('/tmp/xcatDB', create_if_missing=True)
 preimageDB = plyvel.DB('/tmp/preimageDB', create_if_missing=True)
@@ -12,6 +12,7 @@ preimageDB = plyvel.DB('/tmp/preimageDB', create_if_missing=True)
 #############################################
 ######## Trades stored by tradeid ###########
 #############################################
+
 
 # Takes dict or obj, saves json str as bytes
 def create(trade, tradeid):
@@ -21,6 +22,7 @@ def create(trade, tradeid):
         trade = trade.toJSON()
     db.put(b(tradeid), b(trade))
 
+
 #  Uses the funding txid as the key to save trade
 def createByFundtx(trade):
     trade = trade.toJSON()
@@ -29,11 +31,13 @@ def createByFundtx(trade):
     txid = jt['sell']['fund_tx']
     db.put(b(txid), b(trade))
 
+
 def get(tradeid):
     rawtrade = db.get(b(tradeid))
     tradestr = str(rawtrade, 'utf-8')
     trade = instantiate(tradestr)
     return trade
+
 
 def instantiate(trade):
     if type(trade) == str:
@@ -45,9 +49,11 @@ def instantiate(trade):
 ###### Preimages stored by tradeid ##########
 #############################################
 
+
 # Stores secret locally in key/value store by tradeid
 def save_secret(tradeid, secret):
     res = preimageDB.put(b(tradeid), b(secret))
+
 
 def get_secret(tradeid):
     secret = preimageDB.get(b(tradeid))
@@ -66,6 +72,7 @@ def dump():
             j = json.loads(x2s(b2x(v)))
             results.append((str(k, 'utf-8'), j))
     return results
+
 
 def print_entries():
     it = db.iterator()

--- a/xcat/db.py
+++ b/xcat/db.py
@@ -1,7 +1,7 @@
 import plyvel
 import json
 import xcat.utils as utils
-from xcat.trades import Trade, Contract
+from xcat.trades import Trade
 
 
 class DB():
@@ -63,7 +63,7 @@ class DB():
         results = []
         with self.db.iterator() as it:
             for k, v in it:
-                j = json.loads(utils.x2s(utils.b2x(v)))
+                j = json.loads(str(v, 'utf-8'))
                 results.append((str(k, 'utf-8'), j))
         return results
 

--- a/xcat/protocol.py
+++ b/xcat/protocol.py
@@ -1,224 +1,245 @@
-import json
-import os, sys
-from pprint import pprint
-from xcat.utils import *
-from xcat.trades import Contract, Trade
 import xcat.userInput as userInput
 import xcat.db as db
-from xcat.xcatconf import *
+import xcat.utils as utils
+from xcat.xcatconf import ADDRS
+from xcat.trades import Contract, Trade
 from xcat.bitcoinRPC import bitcoinProxy
 from xcat.zcashRPC import zcashProxy
 
-bitcoinRPC = bitcoinProxy()
-zcashRPC = zcashProxy()
 
-def is_myaddr(address):
-    if address[:1] == 'm':
-        status = bitcoinRPC.validateaddress(address)
-    else:
-        status = zcashRPC.validateaddress(address)
-    status = status['ismine']
-    # print("Address {0} is mine: {1}".format(address, status))
-    return status
+class Protocol():
 
-def find_secret_from_fundtx(currency, p2sh, fundtx):
-    if currency == 'bitcoin':
-        secret = bitcoinRPC.find_secret(p2sh, fundtx)
-    else:
-        secret = zcashRPC.find_secret(p2sh, fundtx)
-    return secret
+    def __init__(self):
+        self.bitcoinRPC = bitcoinProxy()
+        self.zcashRPC = zcashProxy()
 
-def import_addrs(trade):
-    check_fund_status(trade.sell.currency, trade.sell.p2sh)
-    check_fund_status(trade.buy.currency, trade.buy.p2sh)
-
-def check_p2sh(currency, address):
-    if currency == 'bitcoin':
-        print("Checking funds in Bitcoin p2sh")
-        return bitcoinRPC.check_funds(address)
-    else:
-        print("Checking funds in Zcash p2sh")
-        return zcashRPC.check_funds(address)
-
-def check_fund_status(currency, address):
-    if currency == 'bitcoin':
-        print("Checking funds in Bitcoin p2sh")
-        return bitcoinRPC.get_fund_status(address)
-    else:
-        print("Checking funds in Zcash p2sh")
-        return zcashRPC.get_fund_status(address)
-
-# TODO: function to calculate appropriate locktimes between chains
-# def verify_p2sh(trade):
-    # htlc = create_htlc(trade.buy.currency, trade.buy.fulfiller, trade.buy.initiator, trade.commitment, trade.buy.locktime)
-    # buyer_p2sh = htlc['p2sh']
-    # print("Buyer p2sh:", buyer_p2sh)
-    # If the two p2sh match...
-    # if buyer_p2sh == trade.buy.p2sh:
-    # else:
-    #     print("Compiled p2sh for htlc does not match what seller sent.")
-
-def create_htlc(currency, funder, redeemer, commitment, locktime):
-    if currency == 'bitcoin':
-        sell_p2sh = bitcoinRPC.hashtimelockcontract(funder, redeemer, commitment, locktime)
-    else:
-        sell_p2sh = zcashRPC.hashtimelockcontract(funder, redeemer, commitment, locktime)
-    return sell_p2sh
-
-def fund_htlc(currency, p2sh, amount):
-    if currency == 'bitcoin':
-        txid = bitcoinRPC.fund_htlc(p2sh, amount)
-    else:
-        txid = zcashRPC.fund_htlc(p2sh, amount)
-    return txid
-
-def fund_contract(contract):
-    txid = fund_htlc(contract.currency, contract.p2sh, contract.amount)
-    return txid
-
-def fund_sell_contract(trade):
-    sell = trade.sell
-    txid = fund_htlc(sell.currency, sell.p2sh, sell.amount)
-    setattr(trade.sell, 'fund_tx', txid)
-    save(trade)
-    return txid
-
-def create_sell_p2sh(trade, commitment, locktime):
-    # CREATE SELL CONTRACT
-    sell = trade.sell
-    contract = create_htlc(sell.currency, sell.initiator, sell.fulfiller, commitment, locktime)
-    print("sell contract", contract)
-    setattr(trade.sell, 'p2sh', contract['p2sh'])
-    setattr(trade.sell, 'redeemScript', contract['redeemScript'])
-    setattr(trade.sell, 'redeemblocknum', contract['redeemblocknum'])
-    setattr(trade.buy, 'locktime', contract['locktime'])
-    save(trade)
-
-def create_buy_p2sh(trade, commitment, locktime):
-    ## CREATE BUY CONTRACT
-    buy = trade.buy
-    print("\nNow creating buy contract on the {0} blockchain where you will wait for the buyer to send funds...".format(buy.currency))
-    buy_contract = create_htlc(buy.currency, buy.fulfiller, buy.initiator, commitment, locktime)
-    print("Buy contract", buy_contract)
-
-    setattr(trade.buy, 'p2sh', buy_contract['p2sh'])
-    setattr(trade.buy, 'redeemScript', buy_contract['redeemScript'])
-    setattr(trade.buy, 'redeemblocknum', buy_contract['redeemblocknum'])
-    setattr(trade.buy, 'locktime', buy_contract['locktime'])
-    print("\nNow contact the buyer and tell them to send funds to this p2sh: {0}\n".format(trade.buy.p2sh))
-
-    save(trade)
-
-def redeem_p2sh(contract, secret):
-    currency = contract.currency
-    if currency == 'bitcoin':
-        res = bitcoinRPC.redeem_contract(contract, secret)
-    else:
-        res = zcashRPC.redeem_contract(contract, secret)
-    return res
-
-def parse_secret(chain, txid):
-    if chain == 'bitcoin':
-        secret = bitcoinRPC.parse_secret(txid)
-    else:
-        secret = zcashRPC.parse_secret(txid)
-    return secret
-
-####  Main functions determining user flow from command line
-def buyer_redeem(trade):
-    userInput.authorize_buyer_redeem(trade)
-    if trade.sell.get_status() == 'redeemed':
-        print("You already redeemed the funds and acquired {0} {1}".format(trade.sell.amount, trade.sell.currency))
-        exit()
-    else:
-        # Buyer redeems seller's funded tx
-        p2sh = trade.sell.p2sh
-        currency = trade.sell.currency
-        # Buy contract is where seller disclosed secret in redeeming
-        if trade.buy.currency == 'bitcoin':
-            secret = bitcoinRPC.parse_secret(trade.buy.redeem_tx)
+    def is_myaddr(self, address):
+        if address[:1] == 'm':
+            status = self.bitcoinRPC.validateaddress(address)
         else:
-            secret = zcashRPC.parse_secret(trade.buy.redeem_tx)
-        print("Found secret in seller's redeem tx", secret)
-        redeem_tx = redeem_p2sh(trade.sell, secret)
-        setattr(trade.sell, 'redeem_tx', redeem_tx)
-        save(trade)
-    exit()
+            status = self.zcashRPC.validateaddress(address)
+        status = status['ismine']
+        # print("Address {0} is mine: {1}".format(address, status))
+        return status
 
-def seller_redeem_p2sh(trade, secret):
-    buy = trade.buy
-    userInput.authorize_seller_redeem(buy)
+    def find_secret_from_fundtx(self, currency, p2sh, fundtx):
+        if currency == 'bitcoin':
+            secret = self.bitcoinRPC.find_secret(p2sh, fundtx)
+        else:
+            secret = self.zcashRPC.find_secret(p2sh, fundtx)
+        return secret
 
-    if trade.sell.get_status() == 'redeemed':
-        print("You already redeemed the funds and acquired {0} {1}".format(buy.amount, buy.currency))
+    def import_addrs(self, trade):
+        self.check_fund_status(trade.sell.currency, trade.sell.p2sh)
+        self.check_fund_status(trade.buy.currency, trade.buy.p2sh)
+
+    def check_p2sh(self, currency, address):
+        if currency == 'bitcoin':
+            print("Checking funds in Bitcoin p2sh")
+            return self.bitcoinRPC.check_funds(address)
+        else:
+            print("Checking funds in Zcash p2sh")
+            return self.zcashRPC.check_funds(address)
+
+    def check_fund_status(self, currency, address):
+        if currency == 'bitcoin':
+            print("Checking funds in Bitcoin p2sh")
+            return self.bitcoinRPC.get_fund_status(address)
+        else:
+            print("Checking funds in Zcash p2sh")
+            return self.zcashRPC.get_fund_status(address)
+
+    # TODO: function to calculate appropriate locktimes between chains
+    # def verify_p2sh(trade):
+        # htlc = self.create_htlc(
+        #    trade.buy.currency, trade.buy.fulfiller,
+        #    trade.buy.initiator, trade.commitment,
+        #     trade.buy.locktime)
+        # buyer_p2sh = htlc['p2sh']
+        # print("Buyer p2sh:", buyer_p2sh)
+        # If the two p2sh match...
+        # if buyer_p2sh == trade.buy.p2sh:
+        # else:
+        #     print("Compiled p2sh for htlc does not match what seller sent.")
+
+    def create_htlc(self, currency, funder, redeemer, commitment, locktime):
+        if currency == 'bitcoin':
+            sell_p2sh = self.bitcoinRPC.hashtimelockcontract(
+                funder, redeemer, commitment, locktime)
+        else:
+            sell_p2sh = self.zcashRPC.hashtimelockcontract(
+                funder, redeemer, commitment, locktime)
+        return sell_p2sh
+
+    def fund_htlc(self, currency, p2sh, amount):
+        if currency == 'bitcoin':
+            txid = self.bitcoinRPC.fund_htlc(p2sh, amount)
+        else:
+            txid = self.zcashRPC.fund_htlc(p2sh, amount)
+        return txid
+
+    def fund_contract(self, contract):
+        txid = self.fund_htlc(
+            contract.currency, contract.p2sh, contract.amount)
+        return txid
+
+    def fund_sell_contract(self, trade):
+        sell = trade.sell
+        txid = self.fund_htlc(sell.currency, sell.p2sh, sell.amount)
+        setattr(trade.sell, 'fund_tx', txid)
+        utils.save(trade)
+        return txid
+
+    def create_sell_p2sh(self, trade, commitment, locktime):
+        # CREATE SELL CONTRACT
+        sell = trade.sell
+        contract = self.create_htlc(sell.currency, sell.initiator,
+                                    sell.fulfiller, commitment, locktime)
+        print("sell contract", contract)
+        setattr(trade.sell, 'p2sh', contract['p2sh'])
+        setattr(trade.sell, 'redeemScript', contract['redeemScript'])
+        setattr(trade.sell, 'redeemblocknum', contract['redeemblocknum'])
+        setattr(trade.buy, 'locktime', contract['locktime'])
+        utils.save(trade)
+
+    def create_buy_p2sh(self, trade, commitment, locktime):
+        # CREATE BUY CONTRACT
+        buy = trade.buy
+        print("\nNow creating buy contract on the {0} blockchain where you "
+              "will wait for the buyer to send funds...".format(buy.currency))
+        buy_contract = self.create_htlc(
+            buy.currency, buy.fulfiller, buy.initiator, commitment, locktime)
+        print("Buy contract", buy_contract)
+
+        setattr(trade.buy, 'p2sh', buy_contract['p2sh'])
+        setattr(trade.buy, 'redeemScript', buy_contract['redeemScript'])
+        setattr(trade.buy, 'redeemblocknum', buy_contract['redeemblocknum'])
+        setattr(trade.buy, 'locktime', buy_contract['locktime'])
+        print("\nNow contact the buyer and tell them to send funds to this "
+              "p2sh: {0}\n".format(trade.buy.p2sh))
+
+        utils.save(trade)
+
+    def redeem_p2sh(self, contract, secret):
+        currency = contract.currency
+        if currency == 'bitcoin':
+            res = self.bitcoinRPC.redeem_contract(contract, secret)
+        else:
+            res = self.zcashRPC.redeem_contract(contract, secret)
+        return res
+
+    def parse_secret(self, chain, txid):
+        if chain == 'bitcoin':
+            secret = self.bitcoinRPC.parse_secret(txid)
+        else:
+            secret = self.zcashRPC.parse_secret(txid)
+        return secret
+
+    #  Main functions determining user flow from command line
+    def buyer_redeem(self, trade):
+        userInput.authorize_buyer_redeem(trade)
+        if trade.sell.get_status() == 'redeemed':
+            print("You already redeemed the funds and acquired "
+                  "{0} {1}".format(trade.sell.amount, trade.sell.currency))
+            exit()
+        else:
+            # Buyer redeems seller's funded tx
+            # p2sh = trade.sell.p2sh
+            # currency = trade.sell.currency
+            # Buy contract is where seller disclosed secret in redeeming
+            if trade.buy.currency == 'bitcoin':
+                secret = self.bitcoinRPC.parse_secret(trade.buy.redeem_tx)
+            else:
+                secret = self.zcashRPC.parse_secret(trade.buy.redeem_tx)
+            print("Found secret in seller's redeem tx", secret)
+            redeem_tx = self.redeem_p2sh(trade.sell, secret)
+            setattr(trade.sell, 'redeem_tx', redeem_tx)
+            utils.save(trade)
         exit()
-    else:
-        # Seller redeems buyer's funded tx (contract in p2sh)
-        txs = redeem_p2sh(trade.buy, secret)
-        print("You have redeemed {0} {1}!".format(buy.amount, buy.currency))
-        return txs
 
-def buyer_fulfill(trade):
-    buy = trade.buy
-    sell = trade.sell
-    buy_p2sh_balance = check_p2sh(buy.currency, buy.p2sh)
-    sell_p2sh_balance = check_p2sh(sell.currency, sell.p2sh)
+    def seller_redeem_p2sh(self, trade, secret):
+        buy = trade.buy
+        userInput.authorize_seller_redeem(buy)
 
-    if buy_p2sh_balance == 0:
-        userInput.authorize_buyer_fulfill(sell_p2sh_balance, sell.currency, buy_p2sh_balance, buy.currency)
-        print("Buy amt:", buy.amount)
-        txid = fund_buy_contract(trade)
-        print("Fund tx txid:", txid)
-    else:
-        print("It looks like you've already funded the contract to buy {1}, the amount in escrow in the p2sh is {0}.".format(buy_p2sh_balance, buy.currency))
-        print("Please wait for the seller to remove your funds from escrow to complete the trade.")
-    print_trade('buyer')
+        if trade.sell.get_status() == 'redeemed':
+            print("You already redeemed the funds and acquired "
+                  "{0} {1}".format(buy.amount, buy.currency))
+            exit()
+        else:
+            # Seller redeems buyer's funded tx (contract in p2sh)
+            txs = self.redeem_p2sh(trade.buy, secret)
+            print("You have redeemed "
+                  "{0} {1}!".format(buy.amount, buy.currency))
+            return txs
 
-def initialize_trade(tradeid, **kwargs):
-    trade = Trade()
-    conf = kwargs['conf']
-    if conf == 'cli':
-        init_addrs = userInput.get_initiator_addresses()
-        fulfill_addrs = userInput.get_fulfiller_addresses()
-        amounts = userInput.get_trade_amounts()
-        print("AMOUNTS", amounts)
-    else:
-        init_addrs = ADDRS[conf]['initiator']
-        fulfill_addrs = ADDRS[conf]['fulfiller']
-        amounts = ADDRS[conf]['amounts']
+    def buyer_fulfill(self, trade):
+        buy = trade.buy
+        sell = trade.sell
+        buy_p2sh_balance = self.check_p2sh(buy.currency, buy.p2sh)
+        sell_p2sh_balance = self.check_p2sh(sell.currency, sell.p2sh)
 
-    sell = amounts['sell']
-    buy = amounts['buy']
-    sell_currency = sell['currency']
-    buy_currency = buy['currency']
-    sell['initiator'] = init_addrs[sell_currency]
-    buy['initiator'] = init_addrs[buy_currency]
-    sell['fulfiller'] = fulfill_addrs[sell_currency]
-    buy['fulfiller'] = fulfill_addrs[buy_currency]
+        if buy_p2sh_balance == 0:
+            userInput.authorize_buyer_fulfill(
+                sell_p2sh_balance,
+                sell.currency,
+                buy_p2sh_balance,
+                buy.currency)
+            print("Buy amt:", buy.amount)
+            txid = fund_buy_contract(trade)
+            print("Fund tx txid:", txid)
+        else:
+            print("It looks like you've already funded the contract to buy "
+                  "{1}, the amount in escrow in the p2sh is "
+                  "{0}.".format(buy_p2sh_balance, buy.currency))
+            print("Please wait for the seller to remove your funds from "
+                  "escrow to complete the trade.")
+        print_trade('buyer')
 
-    # initializing contract classes with addresses, currencies, and amounts
-    trade.sell = Contract(sell)
-    trade.buy = Contract(buy)
-    print(trade.sell.__dict__)
-    print(trade.buy.__dict__)
-    return tradeid, trade
+    def initialize_trade(self, tradeid, **kwargs):
+        trade = Trade()
+        conf = kwargs['conf']
+        if conf == 'cli':
+            init_addrs = userInput.get_initiator_addresses()
+            fulfill_addrs = userInput.get_fulfiller_addresses()
+            amounts = userInput.get_trade_amounts()
+            print("AMOUNTS", amounts)
+        else:
+            init_addrs = ADDRS[conf]['initiator']
+            fulfill_addrs = ADDRS[conf]['fulfiller']
+            amounts = ADDRS[conf]['amounts']
 
+        sell = amounts['sell']
+        buy = amounts['buy']
+        sell_currency = sell['currency']
+        buy_currency = buy['currency']
+        sell['initiator'] = init_addrs[sell_currency]
+        buy['initiator'] = init_addrs[buy_currency]
+        sell['fulfiller'] = fulfill_addrs[sell_currency]
+        buy['fulfiller'] = fulfill_addrs[buy_currency]
 
-def seller_init(tradeid, trade):
-    secret = generate_password()
-    db.save_secret(tradeid, secret)
-    print("\nGenerated a secret preimage to lock funds. This will only be stored locally: ", secret)
+        # initializing contract classes with addresses, currencies, and amounts
+        trade.sell = Contract(sell)
+        trade.buy = Contract(buy)
+        print(trade.sell.__dict__)
+        print(trade.buy.__dict__)
+        return tradeid, trade
 
-    hash_of_secret = sha256(secret)
-    # TODO: Implement locktimes and mock block passage of time
-    sell_locktime = 20
-    buy_locktime = 10 # Must be more than first tx
-    print("Creating pay-to-script-hash for sell contract...")
+    def seller_init(self, tradeid, trade):
+        secret = utils.generate_password()
+        db.save_secret(tradeid, secret)
+        print("\nGenerated a secret preimage to lock funds. This will only "
+              "be stored locally: ", secret)
 
-    # create the p2sh addrs
-    create_sell_p2sh(trade, hash_of_secret, sell_locktime)
-    create_buy_p2sh(trade, hash_of_secret, buy_locktime)
+        hash_of_secret = utils.sha256(secret)
+        # TODO: Implement locktimes and mock block passage of time
+        sell_locktime = 20
+        buy_locktime = 10  # Must be more than first tx
+        print("Creating pay-to-script-hash for sell contract...")
 
-    trade.commitment = b2x(hash_of_secret)
-    print("TRADE after seller init", trade.toJSON())
-    return trade
+        # create the p2sh addrs
+        self.create_sell_p2sh(trade, hash_of_secret, sell_locktime)
+        self.create_buy_p2sh(trade, hash_of_secret, buy_locktime)
+
+        trade.commitment = utils.b2x(hash_of_secret)
+        print("TRADE after seller init", trade.toJSON())
+        return trade

--- a/xcat/protocol.py
+++ b/xcat/protocol.py
@@ -260,7 +260,7 @@ class Protocol():
         print(trade.buy.__dict__)
         return tradeid, trade
 
-    def seller_init(self, tradeid, trade):
+    def seller_init(self, tradeid, trade, network):
         secret = utils.generate_password()
         db.save_secret(tradeid, secret)
         print("\nGenerated a secret preimage to lock funds. This will only "

--- a/xcat/protocol.py
+++ b/xcat/protocol.py
@@ -1,11 +1,11 @@
+import logging
 import xcat.userInput as userInput
-import xcat.db as db
 import xcat.utils as utils
 from xcat.xcatconf import ADDRS
 from xcat.trades import Contract, Trade
 from xcat.bitcoinRPC import bitcoinProxy
 from xcat.zcashRPC import zcashProxy
-import logging
+from xcat.db import DB
 
 
 class Protocol():
@@ -261,6 +261,7 @@ class Protocol():
         return tradeid, trade
 
     def seller_init(self, tradeid, trade, network):
+        db = DB()
         secret = utils.generate_password()
         db.save_secret(tradeid, secret)
         print("\nGenerated a secret preimage to lock funds. This will only "

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -70,6 +70,21 @@ class TestCLI(unittest.TestCase):
 
         self.assertEqual(res, 'fulfiller')
 
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_error(self, mock_protocol):
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'you'
+        test_contract.fulfiller = 'you'
+
+        with self.assertRaises(ValueError) as context:
+            cli.find_role(test_contract)
+
+        self.assertTrue(
+            'You are not a participant in this contract.'
+            in str(context.exception))
+
     def test_checktrade(self):
         pass
 

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -1,111 +1,59 @@
 import unittest
-import unittest.mock as mock
 import xcat.cli as cli
-# from xcat.tests.utils import test_trade
-# from xcat.trades import Trade
+import xcat.db as db
+from xcat.protocol import Protocol
+from xcat.tests.utils import mktrade
+from xcat.trades import Trade  # , Contract
 
 
-class TestCLI(unittest.TestCase):
-
-    def test_save_state(self):
-        pass
-
-    def test_checkSellStatus(self):
-        pass
-
-    def test_buyer_check_status(self):
-        pass
-
-    def test_seller_check_status(self):
-        pass
-
-    def test_checkBuyStatus(self):
-        pass
-
-    def test_importtrade(self):
-        pass
-
-    def test_wormhole_importtrade(self):
-        pass
+class SimpleTestCase(unittest.TestCase):
+    def setUp(self):
+        self.trade = mktrade()
 
     def test_exporttrade(self):
+        self.__class__.hexstr = cli.exporttrade('test')
+        self.assertTrue(int(self.hexstr, 16))
+
+    def test_importtrade(self):
+        # trade = cli.importtrade('test', self.__class__.hexstr)
         pass
 
+
+class CliTest(SimpleTestCase):
     def test_findtrade(self):
-        pass
-
-    @mock.patch('xcat.cli.Protocol')
-    def test_find_role_test(self, mock_protocol):
-        mock_protocol().is_myaddr = lambda k: k == 'me'
-
-        test_contract = mock.MagicMock()
-        test_contract.initiator = 'me'
-        test_contract.fulfiller = 'me'
-
-        res = cli.find_role(test_contract)
-
-        self.assertEqual(res, 'test')
-
-    @mock.patch('xcat.cli.Protocol')
-    def test_find_role_initiator(self, mock_protocol):
-        mock_protocol().is_myaddr = lambda k: k == 'me'
-
-        test_contract = mock.MagicMock()
-        test_contract.initiator = 'me'
-        test_contract.fulfiller = 'you'
-
-        res = cli.find_role(test_contract)
-
-        self.assertEqual(res, 'initiator')
-
-    @mock.patch('xcat.cli.Protocol')
-    def test_find_role_fulfiller(self, mock_protocol):
-        mock_protocol().is_myaddr = lambda k: k == 'me'
-
-        test_contract = mock.MagicMock()
-        test_contract.initiator = 'you'
-        test_contract.fulfiller = 'me'
-
-        res = cli.find_role(test_contract)
-
-        self.assertEqual(res, 'fulfiller')
-
-    @mock.patch('xcat.cli.Protocol')
-    def test_find_role_error(self, mock_protocol):
-        mock_protocol().is_myaddr = lambda k: k == 'me'
-
-        test_contract = mock.MagicMock()
-        test_contract.initiator = 'you'
-        test_contract.fulfiller = 'you'
-
-        with self.assertRaises(ValueError) as context:
-            cli.find_role(test_contract)
-
-        self.assertTrue(
-            'You are not a participant in this contract.'
-            in str(context.exception))
-
-    def test_checktrade(self):
+        # trade = cli.findtrade('test')
         pass
 
     def test_newtrade(self):
-        pass
-
-    def test_listtrades(self):
-        pass
+        trade = cli.newtrade('new', conf='regtest')
+        self.assertTrue(isinstance(trade, Trade))
 
     def test_fundsell(self):
-        pass
+        protocol = Protocol()
 
-    def test_fundbuy(self):
-        pass
+        trade = db.get('new')
+        status = cli.seller_check_status(trade)
+        print("Trade status: {0}\n".format(status))
+        self.assertEqual(status, 'init')
 
-    def test_seller_redeem(self):
-        pass
+        fund_tx = protocol.fund_sell_contract(trade)
+        print("Sent fund_tx", fund_tx)
 
-    def test_buyer_redeem(self):
-        pass
-
+    # def test_fundbuy(self):
+    #     trade = db.get('new')
+    #     status = cli.buyer_check_status(trade)
+    #     self.assertEqual(status, 'sellerFunded')
+    #     fund_tx = cli.fund_contract(trade.buy)
+    #
+    # def test_seller_redeem(self):
+    #     trade = db.get('new')
+    #     status = cli.seller_check_status(trade)
+    #     self.assertEqual(status, 'buyerFunded')
+    #
+    # def test_buyer_redeem(self):
+    #     trade = db.get('new')
+    #     status = cli.buyer_check_status(trade)
+    #     self.assertEqual(status, 'sellerFunded')
 
 if __name__ == '__main__':
     unittest.main()

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -1,8 +1,8 @@
 import unittest
 import unittest.mock as mock
 import xcat.cli as cli
-from xcat.tests.utils import test_trade
-from xcat.trades import Trade
+# from xcat.tests.utils import test_trade
+# from xcat.trades import Trade
 
 
 class TestCLI(unittest.TestCase):
@@ -34,7 +34,24 @@ class TestCLI(unittest.TestCase):
     def test_findtrade(self):
         pass
 
-    def test_find_role(self):
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_test(self, mock_protocol):
+        mock_protocol().is_myaddr.return_value = True
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'test initiator'
+        test_contract.fulfiller = 'test fulfiller'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'test')
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_initiator(self, mock_protocol):
+        pass
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_fulfiller(self, mock_protocol):
         pass
 
     def test_checktrade(self):

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -36,11 +36,11 @@ class TestCLI(unittest.TestCase):
 
     @mock.patch('xcat.cli.Protocol')
     def test_find_role_test(self, mock_protocol):
-        mock_protocol().is_myaddr.return_value = True
+        mock_protocol().is_myaddr = lambda k: k == 'me'
 
         test_contract = mock.MagicMock()
-        test_contract.initiator = 'test initiator'
-        test_contract.fulfiller = 'test fulfiller'
+        test_contract.initiator = 'me'
+        test_contract.fulfiller = 'me'
 
         res = cli.find_role(test_contract)
 
@@ -48,11 +48,27 @@ class TestCLI(unittest.TestCase):
 
     @mock.patch('xcat.cli.Protocol')
     def test_find_role_initiator(self, mock_protocol):
-        pass
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'me'
+        test_contract.fulfiller = 'you'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'initiator')
 
     @mock.patch('xcat.cli.Protocol')
     def test_find_role_fulfiller(self, mock_protocol):
-        pass
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'you'
+        test_contract.fulfiller = 'me'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'fulfiller')
 
     def test_checktrade(self):
         pass

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -2,13 +2,13 @@ import unittest
 import xcat.cli as cli
 from xcat.db import DB
 from xcat.protocol import Protocol
-from xcat.tests.utils import mktrade
+import xcat.tests.utils as testutils
 from xcat.trades import Trade  # , Contract
 
 
 class SimpleTestCase(unittest.TestCase):
     def setUp(self):
-        self.trade = mktrade()
+        self.trade = testutils.mktrade()
 
     def test_exporttrade(self):
         self.__class__.hexstr = cli.exporttrade('test')
@@ -20,6 +20,7 @@ class SimpleTestCase(unittest.TestCase):
 
 
 class CliTest(SimpleTestCase):
+
     def test_findtrade(self):
         # trade = cli.findtrade('test')
         pass
@@ -33,6 +34,7 @@ class CliTest(SimpleTestCase):
         protocol = Protocol()
 
         trade = db.get('new')
+
         status = cli.seller_check_status(trade)
         print("Trade status: {0}\n".format(status))
         self.assertEqual(status, 'init')

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -1,8 +1,8 @@
 import unittest
 import xcat.cli as cli
+import xcat.tests.utils as testutils
 from xcat.db import DB
 from xcat.protocol import Protocol
-import xcat.tests.utils as testutils
 from xcat.trades import Trade  # , Contract
 
 

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -1,6 +1,6 @@
 import unittest
 import xcat.cli as cli
-import xcat.db as db
+from xcat.db import DB
 from xcat.protocol import Protocol
 from xcat.tests.utils import mktrade
 from xcat.trades import Trade  # , Contract
@@ -29,6 +29,7 @@ class CliTest(SimpleTestCase):
         self.assertTrue(isinstance(trade, Trade))
 
     def test_fundsell(self):
+        db = DB()
         protocol = Protocol()
 
         trade = db.get('new')
@@ -54,6 +55,7 @@ class CliTest(SimpleTestCase):
     #     trade = db.get('new')
     #     status = cli.buyer_check_status(trade)
     #     self.assertEqual(status, 'sellerFunded')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/xcat/tests/test_cli.py
+++ b/xcat/tests/test_cli.py
@@ -1,53 +1,62 @@
 import unittest
+import unittest.mock as mock
 import xcat.cli as cli
-import xcat.db as db
-from xcat.tests.utils import mktrade
-from xcat.trades import Trade, Contract
+from xcat.tests.utils import test_trade
+from xcat.trades import Trade
 
 
-class SimpleTestCase(unittest.TestCase):
-    def setUp(self):
-        self.trade = mktrade()
+class TestCLI(unittest.TestCase):
 
-    def test_exporttrade(self):
-        self.__class__.hexstr = cli.exporttrade('test')
-        self.assertTrue(int(self.hexstr, 16))
+    def test_save_state(self):
+        pass
+
+    def test_checkSellStatus(self):
+        pass
+
+    def test_buyer_check_status(self):
+        pass
+
+    def test_seller_check_status(self):
+        pass
+
+    def test_checkBuyStatus(self):
+        pass
 
     def test_importtrade(self):
-        trade = cli.importtrade('test', self.__class__.hexstr)
+        pass
 
+    def test_wormhole_importtrade(self):
+        pass
 
-class CliTest(SimpleTestCase):
+    def test_exporttrade(self):
+        pass
+
     def test_findtrade(self):
-        trade = cli.findtrade('test')
+        pass
+
+    def test_find_role(self):
+        pass
+
+    def test_checktrade(self):
+        pass
 
     def test_newtrade(self):
-        trade = cli.newtrade('new', conf='regtest')
-        self.assertTrue(isinstance(trade, Trade))
+        pass
+
+    def test_listtrades(self):
+        pass
 
     def test_fundsell(self):
-        trade = db.get('new')
-        status = cli.seller_check_status(trade)
-        print("Trade status: {0}\n".format(status))
-        self.assertEqual(status, 'init')
-        fund_tx = cli.fund_sell_contract(trade)
-        print("Sent fund_tx", fund_tx)
+        pass
 
-    # def test_fundbuy(self):
-    #     trade = db.get('new')
-    #     status = cli.buyer_check_status(trade)
-    #     self.assertEqual(status, 'sellerFunded')
-    #     fund_tx = cli.fund_contract(trade.buy)
-    #
-    # def test_seller_redeem(self):
-    #     trade = db.get('new')
-    #     status = cli.seller_check_status(trade)
-    #     self.assertEqual(status, 'buyerFunded')
-    #
-    # def test_buyer_redeem(self):
-    #     trade = db.get('new')
-    #     status = cli.buyer_check_status(trade)
-    #     self.assertEqual(status, 'sellerFunded')
+    def test_fundbuy(self):
+        pass
+
+    def test_seller_redeem(self):
+        pass
+
+    def test_buyer_redeem(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/xcat/tests/test_db.py
+++ b/xcat/tests/test_db.py
@@ -1,6 +1,6 @@
 import unittest
 import xcat.trades as trades
-import xcat.db as db
+from xcat.db import DB
 
 
 class DatabaseTest(unittest.TestCase):
@@ -10,6 +10,7 @@ class DatabaseTest(unittest.TestCase):
         self.sell = trades.Contract(self.data['sell'])
 
     def test_create(self):
+        db = DB()
         sell = trades.Contract(self.data['sell'])
         buy = trades.Contract(self.data['buy'])
         trade = trades.Trade(sell, buy, commitment=self.data['commitment'])

--- a/xcat/tests/test_db.py
+++ b/xcat/tests/test_db.py
@@ -1,6 +1,6 @@
 import unittest
 import xcat.trades as trades
-import xcat.database as db
+import xcat.db as db
 
 
 class DatabaseTest(unittest.TestCase):

--- a/xcat/tests/test_db.py
+++ b/xcat/tests/test_db.py
@@ -1,8 +1,10 @@
-import xcat.database as db
-import unittest, json
+import unittest
 import xcat.trades as trades
+import xcat.database as db
+
 
 class DatabaseTest(unittest.TestCase):
+
     def setUp(self):
         self.data = {"sell": {"amount": 0.1, "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9147788b4511a25fba1092e67b307a6dcdb6da125d967022a04b17576a914c7043e62a7391596116f54f6a64c8548e97d3fd96888ac", "redeemblocknum": 1066, "currency": "bitcoin", "initiator": "myfFr5twPYNwgeXyjCmGcrzXtCmfmWXKYp", "p2sh": "2MuYSQ1uQ4CJg5Y5QL2vMmVPHNJ2KT5aJ6f", "fulfiller": "mrQzUGU1dwsWRx5gsKKSDPNtrsP65vCA3Z", "fund_tx": "5c5e91a89a08b2d6698f50c9fd9bb2fa22da6c74e226c3dd63d59511566a2fdb"}, "buy": {"amount": 0.2, "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9143ea29256c9d2888ca23de42a8b8e69ca2ec235b167023f0db17576a914c5acca6ef39c843c7a9c3ad01b2da95fe2edf5ba6888ac", "redeemblocknum": 3391, "currency": "zcash", "locktime": 10, "initiator": "tmFRXyju7ANM7A9mg75ZjyhFW1UJEhUPwfQ", "p2sh": "t2HP59RpfR34nBCWH4VVD497tkc2ikzgniP", "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"}, "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
         self.sell = trades.Contract(self.data['sell'])
@@ -14,8 +16,9 @@ class DatabaseTest(unittest.TestCase):
         db.create(trade, 'test')
 
     def test_get(self):
-        trade = db.get('test')
+        # trade = db.get('test')
         print("Trade")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/xcat/tests/unit/test_bitcoinRPC.py
+++ b/xcat/tests/unit/test_bitcoinRPC.py
@@ -42,6 +42,14 @@ class TestBitcoinProxy(unittest.TestCase):
             'Allowed networks are regtest, testnet, mainnet.'
             in str(context.exception))
 
+        with self.assertRaises(ValueError) as context_two:
+            proxy = bitcoinProxy(network=819.3)
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Allowed networks are regtest, testnet, mainnet.'
+            in str(context_two.exception))
+
     def test_init_with_invalid_timeout(self, mock_rpc):
         """Test bitcoinProxy.__init__"""
 
@@ -60,3 +68,66 @@ class TestBitcoinProxy(unittest.TestCase):
         self.assertTrue(
             'Timeout should be a positive integer.'
             in str(context_two.exception))
+
+    def test_validateaddress(self, mock_rpc):
+        pass
+
+    def test_find_secret(self, mock_rpc):
+        pass
+
+    def test_parse_secret(self, mock_rpc):
+        pass
+
+    def test_get_keys(self, mock_rpc):
+        pass
+
+    def test_privkey(self, mock_rpc):
+        pass
+
+    def test_hashtimelockcontract(self, mock_rpc):
+        pass
+
+    def test_fund_htlc(self, mock_rpc):
+        pass
+
+    def test_check_funds(self, mock_rpc):
+        pass
+
+    def test_get_fund_status(self, mock_rpc):
+        pass
+
+    def test_search_p2sh(self, mock_rpc):
+        pass
+
+    def test_get_tx_details(self, mock_rpc):
+        pass
+
+    def test_redeem_contract(self, mock_rpc):
+        pass
+
+    def test_redeem(self, mock_rpc):
+        pass
+
+    def test_refund(self, mock_rpc):
+        pass
+
+    def test_parse_script(self, mock_rpc):
+        pass
+
+    def test_find_redeemblocknum(self, mock_rpc):
+        pass
+
+    def test_find_redeemAddr(self, mock_rpc):
+        pass
+
+    def test_find_refundAddr(self, mock_rpc):
+        pass
+
+    def test_find_transaction_to_address(self, mock_rpc):
+        pass
+
+    def test_new_bitcoin_addr(self, mock_rpc):
+        pass
+
+    def test_generate(self, mock_rpc):
+        pass

--- a/xcat/tests/unit/test_bitcoinRPC.py
+++ b/xcat/tests/unit/test_bitcoinRPC.py
@@ -1,0 +1,62 @@
+import unittest
+import unittest.mock as mock
+from xcat.bitcoinRPC import bitcoinProxy
+import logging
+
+
+@mock.patch('xcat.bitcoinRPC.bitcoin.rpc')
+class TestBitcoinProxy(unittest.TestCase):
+    """Test case for the bitcoinProxy class."""
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('xcat.bitcoinRPC.bitcoin.SelectParams')
+    def test_init_with_testnet(self, mock_SP, mock_rpc):
+        """Test bitcoinProxy.__init__"""
+
+        proxy = bitcoinProxy(network='testnet')
+
+        mock_rpc.Proxy.assert_called_with(timeout=900)
+        mock_SP.assert_called_with('testnet')
+        self.assertIsInstance(proxy, bitcoinProxy)
+
+    @mock.patch('xcat.bitcoinRPC.bitcoin.SelectParams')
+    def test_init_with_no_network(self, mock_SP, mock_rpc):
+        """Test bitcoinProxy.__init__"""
+
+        proxy = bitcoinProxy()
+
+        mock_rpc.Proxy.assert_called_with(timeout=900)
+        mock_SP.assert_called_with('regtest')
+        self.assertIsInstance(proxy, bitcoinProxy)
+
+    def test_init_with_invalid(self, mock_rpc):
+        """Test bitcoinProxy.__init__"""
+
+        with self.assertRaises(ValueError) as context:
+            proxy = bitcoinProxy(network='invalid input')
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Allowed networks are regtest, testnet, mainnet.'
+            in str(context.exception))
+
+    def test_init_with_invalid_timeout(self, mock_rpc):
+        """Test bitcoinProxy.__init__"""
+
+        with self.assertRaises(ValueError) as context:
+            proxy = bitcoinProxy(timeout='invalid input')
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Timeout should be a positive integer.'
+            in str(context.exception))
+
+        with self.assertRaises(ValueError) as context_two:
+            proxy = bitcoinProxy(timeout=-381)
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Timeout should be a positive integer.'
+            in str(context_two.exception))

--- a/xcat/tests/unit/test_cli.py
+++ b/xcat/tests/unit/test_cli.py
@@ -7,8 +7,13 @@ import xcat.cli as cli
 
 class TestCLI(unittest.TestCase):
 
-    def test_save_state(self):
-        pass
+    @mock.patch('xcat.cli.DB')
+    @mock.patch('xcat.cli.utils')
+    def test_save_state(self, mock_utils, mock_db):
+        cli.save_state('fake_trade', 'fake_id')
+
+        mock_utils.save.assert_called_with('fake_trade')
+        mock_db.return_value.create.assert_called_with('fake_trade', 'fake_id')
 
     def test_checkSellStatus(self):
         pass

--- a/xcat/tests/unit/test_cli.py
+++ b/xcat/tests/unit/test_cli.py
@@ -1,0 +1,111 @@
+import unittest
+import unittest.mock as mock
+import xcat.cli as cli
+# from xcat.tests.utils import test_trade
+# from xcat.trades import Trade
+
+
+class TestCLI(unittest.TestCase):
+
+    def test_save_state(self):
+        pass
+
+    def test_checkSellStatus(self):
+        pass
+
+    def test_buyer_check_status(self):
+        pass
+
+    def test_seller_check_status(self):
+        pass
+
+    def test_checkBuyStatus(self):
+        pass
+
+    def test_importtrade(self):
+        pass
+
+    def test_wormhole_importtrade(self):
+        pass
+
+    def test_exporttrade(self):
+        pass
+
+    def test_findtrade(self):
+        pass
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_test(self, mock_protocol):
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'me'
+        test_contract.fulfiller = 'me'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'test')
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_initiator(self, mock_protocol):
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'me'
+        test_contract.fulfiller = 'you'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'initiator')
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_fulfiller(self, mock_protocol):
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'you'
+        test_contract.fulfiller = 'me'
+
+        res = cli.find_role(test_contract)
+
+        self.assertEqual(res, 'fulfiller')
+
+    @mock.patch('xcat.cli.Protocol')
+    def test_find_role_error(self, mock_protocol):
+        mock_protocol().is_myaddr = lambda k: k == 'me'
+
+        test_contract = mock.MagicMock()
+        test_contract.initiator = 'you'
+        test_contract.fulfiller = 'you'
+
+        with self.assertRaises(ValueError) as context:
+            cli.find_role(test_contract)
+
+        self.assertTrue(
+            'You are not a participant in this contract.'
+            in str(context.exception))
+
+    def test_checktrade(self):
+        pass
+
+    def test_newtrade(self):
+        pass
+
+    def test_listtrades(self):
+        pass
+
+    def test_fundsell(self):
+        pass
+
+    def test_fundbuy(self):
+        pass
+
+    def test_seller_redeem(self):
+        pass
+
+    def test_buyer_redeem(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/xcat/tests/unit/test_db.py
+++ b/xcat/tests/unit/test_db.py
@@ -1,0 +1,53 @@
+import unittest
+import unittest.mock as mock
+import xcat.db as db
+import xcat.tests.utils as utils
+
+
+class TestDB(unittest.TestCase):
+
+    @mock.patch('xcat.db.plyvel')
+    def setUp(self, mock_plyvel):
+        self.db = db.DB()
+
+    def test_init(self):
+        self.assertIsInstance(self.db.db, mock.Mock)
+        self.assertIsInstance(self.db.preimageDB, mock.Mock)
+
+    @mock.patch('xcat.db.json')
+    def test_create_with_dict(self, mock_json):
+        test_id = 'test trade id'
+        trade_string = 'trade string'
+        mock_json.dumps.return_value = trade_string
+        test_trade = utils.test_trade
+
+        self.db.create(test_trade, test_id)
+
+        mock_json.dumps.assert_called_with(test_trade)
+        self.db.db.put.assert_called_with(
+            str.encode(test_id),
+            str.encode(trade_string))
+
+    def test_create_with_trade(self):
+        pass
+
+    def test_createByFundtx(self):
+        pass
+
+    def test_get(self):
+        pass
+
+    def test_instantiate(self):
+        pass
+
+    def test_save_secret(self):
+        pass
+
+    def test_get_secret(self):
+        pass
+
+    def test_dump(self):
+        pass
+
+    def test_print_entries(self):
+        pass

--- a/xcat/tests/unit/test_db.py
+++ b/xcat/tests/unit/test_db.py
@@ -1,5 +1,6 @@
 import unittest
 import unittest.mock as mock
+import json
 import xcat.db as db
 import xcat.tests.utils as utils
 
@@ -14,30 +15,61 @@ class TestDB(unittest.TestCase):
         self.assertIsInstance(self.db.db, mock.Mock)
         self.assertIsInstance(self.db.preimageDB, mock.Mock)
 
-    @mock.patch('xcat.db.json')
-    def test_create_with_dict(self, mock_json):
+    def test_create_with_dict(self):
         test_id = 'test trade id'
-        trade_string = 'trade string'
-        mock_json.dumps.return_value = trade_string
-        test_trade = utils.test_trade
 
-        self.db.create(test_trade, test_id)
+        self.db.create(utils.test_trade_dict, test_id)
 
-        mock_json.dumps.assert_called_with(test_trade)
         self.db.db.put.assert_called_with(
             str.encode(test_id),
-            str.encode(trade_string))
+            str.encode(str(utils.test_trade)))
 
     def test_create_with_trade(self):
-        pass
+        test_id = 'test trade id'
 
-    def test_createByFundtx(self):
-        pass
+        self.db.create(utils.test_trade, test_id)
+
+        self.db.db.put.assert_called_with(
+            str.encode(test_id),
+            str.encode(json.dumps(utils.test_trade_dict,
+                                  sort_keys=True,
+                                  indent=4)))
+
+    def test_create_with_error(self):
+        with self.assertRaises(ValueError) as context:
+            self.db.create('this is not valid input', 'trade_id')
+
+        self.assertTrue(
+            'Expected dictionary or Trade object'
+            in str(context.exception))
+
+    def test_createByFundtx_with_dict(self):
+        self.db.createByFundtx(utils.test_trade_dict)
+
+        self.db.db.put.assert_called_with(
+            str.encode('5c5e91a89a08b2d6698f50c9fd9bb2fa22da6c74e226c3dd63d'
+                       '59511566a2fdb'),
+            str.encode(str(utils.test_trade)))
+
+    def test_createByFundtx_with_trade(self):
+        self.db.createByFundtx(utils.test_trade)
+
+        self.db.db.put.assert_called_with(
+            str.encode('5c5e91a89a08b2d6698f50c9fd9bb2fa22da6c74e226c3dd63d'
+                       '59511566a2fdb'),
+            str.encode(json.dumps(utils.test_trade_dict,
+                                  sort_keys=True,
+                                  indent=4)))
+
+    def test_createByFundtx_with_error(self):
+        with self.assertRaises(ValueError) as context:
+            self.db.createByFundtx('this is not valid input')
+
+        self.assertTrue(
+            'Expected dictionary or Trade object'
+            in str(context.exception))
 
     def test_get(self):
-        pass
-
-    def test_instantiate(self):
         pass
 
     def test_save_secret(self):

--- a/xcat/tests/unit/test_db.py
+++ b/xcat/tests/unit/test_db.py
@@ -70,13 +70,26 @@ class TestDB(unittest.TestCase):
             in str(context.exception))
 
     def test_get(self):
-        pass
+        self.db.db.get.return_value = str.encode(utils.test_trade.toJSON())
+
+        trade = self.db.get('test')
+
+        self.assertEqual(trade, utils.test_trade)
 
     def test_save_secret(self):
-        pass
+        self.db.save_secret('my life', 'I like black liquorice')
+
+        self.db.preimageDB.put.assert_called_with(
+            str.encode('my life'),
+            str.encode('I like black liquorice'))
 
     def test_get_secret(self):
-        pass
+        self.db.preimageDB.get.return_value = str.encode(
+            'I like black liquorice')
+
+        secret = self.db.get_secret('my life')
+
+        self.assertEqual(secret, 'I like black liquorice')
 
     def test_dump(self):
         pass

--- a/xcat/tests/unit/test_zcashRPC.py
+++ b/xcat/tests/unit/test_zcashRPC.py
@@ -1,0 +1,133 @@
+import unittest
+import unittest.mock as mock
+from xcat.zcashRPC import zcashProxy
+import logging
+
+
+@mock.patch('xcat.zcashRPC.zcash.rpc')
+class TestBitcoinProxy(unittest.TestCase):
+    """Test case for the zcashProxy class."""
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('xcat.zcashRPC.zcash.SelectParams')
+    def test_init_with_testnet(self, mock_SP, mock_rpc):
+        """Test zcashProxy.__init__"""
+
+        proxy = zcashProxy(network='testnet')
+
+        mock_rpc.Proxy.assert_called_with(timeout=900)
+        mock_SP.assert_called_with('testnet')
+        self.assertIsInstance(proxy, zcashProxy)
+
+    @mock.patch('xcat.zcashRPC.zcash.SelectParams')
+    def test_init_with_no_network(self, mock_SP, mock_rpc):
+        """Test zcashProxy.__init__"""
+
+        proxy = zcashProxy()
+
+        mock_rpc.Proxy.assert_called_with(timeout=900)
+        mock_SP.assert_called_with('regtest')
+        self.assertIsInstance(proxy, zcashProxy)
+
+    def test_init_with_invalid(self, mock_rpc):
+        """Test zcashProxy.__init__"""
+
+        with self.assertRaises(ValueError) as context:
+            proxy = zcashProxy(network='invalid input')
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Allowed networks are regtest, testnet, mainnet.'
+            in str(context.exception))
+
+        with self.assertRaises(ValueError) as context_two:
+            proxy = zcashProxy(network=819.3)
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Allowed networks are regtest, testnet, mainnet.'
+            in str(context_two.exception))
+
+    def test_init_with_invalid_timeout(self, mock_rpc):
+        """Test zcashProxy.__init__"""
+
+        with self.assertRaises(ValueError) as context:
+            proxy = zcashProxy(timeout='invalid input')
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Timeout should be a positive integer.'
+            in str(context.exception))
+
+        with self.assertRaises(ValueError) as context_two:
+            proxy = zcashProxy(timeout=-381)
+            self.assertIsNone(proxy)
+
+        self.assertTrue(
+            'Timeout should be a positive integer.'
+            in str(context_two.exception))
+
+    def test_validateaddress(self, mock_rpc):
+        pass
+
+    def test_find_secret(self, mock_rpc):
+        pass
+
+    def test_parse_secret(self, mock_rpc):
+        pass
+
+    def test_get_keys(self, mock_rpc):
+        pass
+
+    def test_privkey(self, mock_rpc):
+        pass
+
+    def test_hashtimelockcontract(self, mock_rpc):
+        pass
+
+    def test_fund_htlc(self, mock_rpc):
+        pass
+
+    def test_check_funds(self, mock_rpc):
+        pass
+
+    def test_get_fund_status(self, mock_rpc):
+        pass
+
+    def test_search_p2sh(self, mock_rpc):
+        pass
+
+    def test_get_tx_details(self, mock_rpc):
+        pass
+
+    def test_redeem_contract(self, mock_rpc):
+        pass
+
+    def test_redeem(self, mock_rpc):
+        pass
+
+    def test_refund(self, mock_rpc):
+        pass
+
+    def test_parse_script(self, mock_rpc):
+        pass
+
+    def test_find_redeemblocknum(self, mock_rpc):
+        pass
+
+    def test_find_redeemAddr(self, mock_rpc):
+        pass
+
+    def test_find_refundAddr(self, mock_rpc):
+        pass
+
+    def test_find_transaction_to_address(self, mock_rpc):
+        pass
+
+    def test_new_bitcoin_addr(self, mock_rpc):
+        pass
+
+    def test_generate(self, mock_rpc):
+        pass

--- a/xcat/tests/utils.py
+++ b/xcat/tests/utils.py
@@ -1,6 +1,7 @@
 from xcat.db import DB
+from xcat.trades import Contract, Trade
 
-test_trade = {
+test_trade_dict = {
     "sell": {
         "amount": 3.5,
         "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9147788b4511a25fba1092e67b307a6dcdb6da125d967022a04b17576a914c7043e62a7391596116f54f6a64c8548e97d3fd96888ac",
@@ -20,6 +21,12 @@ test_trade = {
         "p2sh": "t2HP59RpfR34nBCWH4VVD497tkc2ikzgniP",
         "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"},
     "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
+
+test_sell_contract = Contract(test_trade_dict['sell'])
+test_buy_contract = Contract(test_trade_dict['buy'])
+test_trade = Trade(sell=test_sell_contract,
+                   buy=test_buy_contract,
+                   commitment=test_trade_dict['commitment'])
 
 
 def mktrade():

--- a/xcat/tests/utils.py
+++ b/xcat/tests/utils.py
@@ -1,4 +1,4 @@
-from xcat import db
+from xcat.db import DB
 
 test_trade = {
     "sell": {
@@ -21,7 +21,9 @@ test_trade = {
         "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"},
     "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
 
+
 def mktrade():
+    db = DB()
     db.create(test_trade, 'test')
     trade = db.get('test')
     return trade

--- a/xcat/tests/utils.py
+++ b/xcat/tests/utils.py
@@ -1,8 +1,20 @@
-import xcat.db as db
-
-test_trade = {"sell": {"amount": 3.5, "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9147788b4511a25fba1092e67b307a6dcdb6da125d967022a04b17576a914c7043e62a7391596116f54f6a64c8548e97d3fd96888ac", "redeemblocknum": 1066, "currency": "bitcoin", "initiator": "myfFr5twPYNwgeXyjCmGcrzXtCmfmWXKYp", "p2sh": "2MuYSQ1uQ4CJg5Y5QL2vMmVPHNJ2KT5aJ6f", "fulfiller": "mrQzUGU1dwsWRx5gsKKSDPNtrsP65vCA3Z", "fund_tx": "5c5e91a89a08b2d6698f50c9fd9bb2fa22da6c74e226c3dd63d59511566a2fdb"}, "buy": {"amount": 1.2, "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9143ea29256c9d2888ca23de42a8b8e69ca2ec235b167023f0db17576a914c5acca6ef39c843c7a9c3ad01b2da95fe2edf5ba6888ac", "redeemblocknum": 3391, "currency": "zcash", "locktime": 10, "initiator": "tmFRXyju7ANM7A9mg75ZjyhFW1UJEhUPwfQ", "p2sh": "t2HP59RpfR34nBCWH4VVD497tkc2ikzgniP", "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"}, "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
-
-def mktrade():
-    db.create(test_trade, 'test')
-    trade = db.get('test')
-    return trade
+test_trade = {
+    "sell": {
+        "amount": 3.5,
+        "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9147788b4511a25fba1092e67b307a6dcdb6da125d967022a04b17576a914c7043e62a7391596116f54f6a64c8548e97d3fd96888ac",
+        "redeemblocknum": 1066,
+        "currency": "bitcoin",
+        "initiator": "myfFr5twPYNwgeXyjCmGcrzXtCmfmWXKYp",
+        "p2sh": "2MuYSQ1uQ4CJg5Y5QL2vMmVPHNJ2KT5aJ6f",
+        "fulfiller": "mrQzUGU1dwsWRx5gsKKSDPNtrsP65vCA3Z",
+        "fund_tx": "5c5e91a89a08b2d6698f50c9fd9bb2fa22da6c74e226c3dd63d59511566a2fdb"},
+    "buy": {
+        "amount": 1.2,
+        "redeemScript": "63a82003d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b68876a9143ea29256c9d2888ca23de42a8b8e69ca2ec235b167023f0db17576a914c5acca6ef39c843c7a9c3ad01b2da95fe2edf5ba6888ac",
+        "redeemblocknum": 3391,
+        "currency": "zcash",
+        "locktime": 10,
+        "initiator": "tmFRXyju7ANM7A9mg75ZjyhFW1UJEhUPwfQ",
+        "p2sh": "t2HP59RpfR34nBCWH4VVD497tkc2ikzgniP",
+        "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"},
+        "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}

--- a/xcat/tests/utils.py
+++ b/xcat/tests/utils.py
@@ -1,3 +1,5 @@
+from xcat import db
+
 test_trade = {
     "sell": {
         "amount": 3.5,
@@ -17,4 +19,9 @@ test_trade = {
         "initiator": "tmFRXyju7ANM7A9mg75ZjyhFW1UJEhUPwfQ",
         "p2sh": "t2HP59RpfR34nBCWH4VVD497tkc2ikzgniP",
         "fulfiller": "tmTjZSg4pX2Us6V5HttiwFZwj464fD2ZgpY"},
-        "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
+    "commitment": "03d58daab37238604b3e57d4a8bdcffa401dc497a9c1aa4f08ffac81616c22b6"}
+
+def mktrade():
+    db.create(test_trade, 'test')
+    trade = db.get('test')
+    return trade

--- a/xcat/trades.py
+++ b/xcat/trades.py
@@ -1,19 +1,23 @@
 import json
 
+
 class Trade(object):
     def __init__(self, sell=None, buy=None, commitment=None):
-        '''Create a new trade with a sell contract and buy contract across two chains'''
+        '''Create a new trade with buy and sell contracts across two chains'''
         self.sell = sell
         self.buy = buy
         self.commitment = commitment
 
     def toJSON(self):
-        return json.dumps(self, default=lambda o: o.__dict__,
-            sort_keys=True, indent=4)
+        return json.dumps(
+            self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
 
 class Contract(object):
     def __init__(self, data):
-        allowed = ('fulfiller', 'initiator', 'currency', 'p2sh', 'amount', 'fund_tx', 'redeem_tx', 'secret', 'redeemScript', 'redeemblocknum', 'locktime')
+        allowed = ('fulfiller', 'initiator', 'currency', 'p2sh', 'amount',
+                   'fund_tx', 'redeem_tx', 'secret', 'redeemScript',
+                   'redeemblocknum', 'locktime')
         for key in data:
             if key in allowed:
                 setattr(self, key, data[key])

--- a/xcat/trades.py
+++ b/xcat/trades.py
@@ -36,14 +36,21 @@ class Trade():
             self.buy.currency,
             self.buy.initiator)
 
+    def __eq__(self, other):
+        return (self.sell == other.sell
+                and self.buy == other.buy
+                and self.commitment == other.commitment)
+
 
 class Contract():
+
+    allowed = ('fulfiller', 'initiator', 'currency', 'p2sh', 'amount',
+               'fund_tx', 'redeem_tx', 'secret', 'redeemScript',
+               'redeemblocknum', 'locktime')
+
     def __init__(self, data):
-        allowed = ('fulfiller', 'initiator', 'currency', 'p2sh', 'amount',
-                   'fund_tx', 'redeem_tx', 'secret', 'redeemScript',
-                   'redeemblocknum', 'locktime')
         for key in data:
-            if key in allowed:
+            if key in Contract.allowed:
                 setattr(self, key, data[key])
 
     def get_status(self):
@@ -56,3 +63,14 @@ class Contract():
             return 'funded'
         else:
             return 'empty'
+
+    def __eq__(self, other):
+        for key in Contract.allowed:
+            if key in self.__dict__:
+                if key not in other.__dict__:
+                    return False
+                if self.__dict__[key] != other.__dict__[key]:
+                    return False
+            if key in other.__dict__ and key not in self.__dict__:
+                return False
+        return True

--- a/xcat/trades.py
+++ b/xcat/trades.py
@@ -1,19 +1,43 @@
 import json
 
 
-class Trade(object):
-    def __init__(self, sell=None, buy=None, commitment=None):
+class Trade():
+    def __init__(self, sell=None, buy=None, commitment=None,
+                 fromJSON=None, fromDict=None):
         '''Create a new trade with buy and sell contracts across two chains'''
-        self.sell = sell
-        self.buy = buy
-        self.commitment = commitment
+
+        if fromJSON is not None and fromDict is None:
+            if isinstance(fromJSON, str):
+                fromDict = json.loads(fromJSON)
+            else:
+                raise ValueError('Expected json string')
+        if fromDict is not None:
+            self.sell = Contract(fromDict['sell'])
+            self.buy = Contract(fromDict['buy'])
+            self.commitment = fromDict['commitment']
+        else:
+            self.sell = sell
+            self.buy = buy
+            self.commitment = commitment
 
     def toJSON(self):
         return json.dumps(
             self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
 
+    def __str__(self):
+        return self.toJSON()
 
-class Contract(object):
+    def __repr__(self):
+        return 'Trade:\n{0} {1} from {2}\nfor\n{3} {4} from {5}'.format(
+            self.sell.amount,
+            self.sell.currency,
+            self.sell.initiator,
+            self.buy.amount,
+            self.buy.currency,
+            self.buy.initiator)
+
+
+class Contract():
     def __init__(self, data):
         allowed = ('fulfiller', 'initiator', 'currency', 'p2sh', 'amount',
                    'fund_tx', 'redeem_tx', 'secret', 'redeemScript',

--- a/xcat/userInput.py
+++ b/xcat/userInput.py
@@ -87,8 +87,8 @@ def authorize_buyer_fulfill(sell_p2sh_balance, sell_currency,
           "in {1}.".format(sell_p2sh_balance, sell_currency))
     input("You have not send funds to the contract to buy {1} "
           "(requested amount: {0}), type 'enter' to allow this program "
-          "to send the agreed upon funds on your behalf.".format(
-            buy_p2sh_balance, buy_currency))
+          "to send the agreed upon funds on your behalf"
+          ".".format(buy_p2sh_balance, buy_currency))
 
 
 def authorize_seller_redeem(buy):

--- a/xcat/userInput.py
+++ b/xcat/userInput.py
@@ -4,9 +4,11 @@ from xcat.bitcoinRPC import bitcoinProxy
 from xcat.zcashRPC import zcashProxy
 from xcat.xcatconf import *
 
+
 def enter_trade_id():
     tradeid = input("Enter a unique identifier for this trade: ")
     return tradeid
+
 
 def get_trade_amounts():
     amounts = {}
@@ -34,9 +36,11 @@ def get_trade_amounts():
     amounts['buy'] = buy
     return amounts
 
+
 def authorize_fund_sell(htlcTrade):
     print('To complete your sell, send {0} {1} to this p2sh: {2}'.format(htlcTrade.sell.amount, htlcTrade.sell.currency, htlcTrade.sell.p2sh))
     response = input("Type 'enter' to allow this program to send funds on your behalf.")
+
 
 def get_initiator_addresses():
     bitcoinRPC = bitcoinProxy()
@@ -50,6 +54,7 @@ def get_initiator_addresses():
     addresses = {'bitcoin': btc_addr, 'zcash': zec_addr}
     return addresses
 
+
 def get_fulfiller_addresses():
     btc_addr = input("Enter the bitcoin address of the party you want to trade with: ")
     if btc_addr == '':
@@ -62,12 +67,15 @@ def get_fulfiller_addresses():
     addresses = {'bitcoin': btc_addr, 'zcash': zec_addr}
     return addresses
 
+
 def authorize_buyer_fulfill(sell_p2sh_balance, sell_currency, buy_p2sh_balance, buy_currency):
     input("The seller's p2sh is funded with {0} {1}, type 'enter' if this is the amount you want to buy in {1}.".format(sell_p2sh_balance, sell_currency))
     input("You have not send funds to the contract to buy {1} (requested amount: {0}), type 'enter' to allow this program to send the agreed upon funds on your behalf.".format(buy_p2sh_balance, buy_currency))
 
+
 def authorize_seller_redeem(buy):
     input("Buyer funded the contract where you offered to buy {0}, type 'enter' to redeem {1} {0} from {2}.".format(buy.currency, buy.amount, buy.p2sh))
+
 
 def authorize_buyer_redeem(trade):
     input("Seller funded the contract where you paid them in {0} to buy {1}, type 'enter' to redeem {2} {1} from {3}.".format(trade.buy.currency, trade.sell.currency, trade.sell.amount, trade.sell.p2sh))

--- a/xcat/userInput.py
+++ b/xcat/userInput.py
@@ -1,8 +1,8 @@
-from xcat.utils import *
-from xcat.db import *
+# from xcat.utils import *
+# from xcat.db import *
 from xcat.bitcoinRPC import bitcoinProxy
 from xcat.zcashRPC import zcashProxy
-from xcat.xcatconf import *
+# from xcat.xcatconf import *
 
 
 def enter_trade_id():
@@ -12,8 +12,9 @@ def enter_trade_id():
 
 def get_trade_amounts():
     amounts = {}
-    sell_currency = input("Which currency would you like to trade out of (bitcoin or zcash)? ")
-    if sell_currency == '' or sell_currency == 'bitcoin' :
+    sell_currency = input("Which currency would you like to trade out of "
+                          "(bitcoin or zcash)? ")
+    if sell_currency == '' or sell_currency == 'bitcoin':
         sell_currency = 'bitcoin'
         buy_currency = 'zcash'
     elif sell_currency == 'zcash':
@@ -22,11 +23,13 @@ def get_trade_amounts():
     else:
         raise ValueError('Mistyped or unspported cryptocurrency pair')
     print(sell_currency)
-    sell_amt = input("How much {0} do you want to sell? ".format(sell_currency))
+    sell_amt = input("How much {0} do you "
+                     "want to sell? ".format(sell_currency))
     if sell_amt == '':
         sell_amt = 0.01
     print(sell_amt)
-    buy_amt = input("How much {0} do you want to receive in exchange? ".format(buy_currency))
+    buy_amt = input("How much {0} do you "
+                    "want to receive in exchange? ".format(buy_currency))
     if buy_amt == '':
         buy_amt = 0.02
     print(buy_amt)
@@ -38,17 +41,22 @@ def get_trade_amounts():
 
 
 def authorize_fund_sell(htlcTrade):
-    print('To complete your sell, send {0} {1} to this p2sh: {2}'.format(htlcTrade.sell.amount, htlcTrade.sell.currency, htlcTrade.sell.p2sh))
-    response = input("Type 'enter' to allow this program to send funds on your behalf.")
+    print('To complete your sell, send {0} {1} to this p2sh: '
+          '{2}'.format(htlcTrade.sell.amount,
+                       htlcTrade.sell.currency,
+                       htlcTrade.sell.p2sh))
+    input("Type 'enter' to allow this program to send funds on your behalf.")
 
 
 def get_initiator_addresses():
     bitcoinRPC = bitcoinProxy()
     zcashRPC = zcashProxy()
-    btc_addr = input("Enter your bitcoin address or press enter to generate one: ")
+    btc_addr = input("Enter your bitcoin address "
+                     "or press enter to generate one: ")
     btc_addr = bitcoinRPC.new_bitcoin_addr()
     print(btc_addr)
-    zec_addr = input("Enter your zcash address or press enter to generate one: ")
+    zec_addr = input("Enter your zcash address "
+                     "or press enter to generate one: ")
     zec_addr = zcashRPC.new_zcash_addr()
     print(zec_addr)
     addresses = {'bitcoin': btc_addr, 'zcash': zec_addr}
@@ -56,26 +64,41 @@ def get_initiator_addresses():
 
 
 def get_fulfiller_addresses():
-    btc_addr = input("Enter the bitcoin address of the party you want to trade with: ")
+    btc_addr = input("Enter the bitcoin address of "
+                     "the party you want to trade with: ")
     if btc_addr == '':
-        btc_addr = "mvc56qCEVj6p57xZ5URNC3v7qbatudHQ9b" # regtest
+        btc_addr = "mvc56qCEVj6p57xZ5URNC3v7qbatudHQ9b"  # regtest
     print(btc_addr)
-    zec_addr = input("Enter the zcash address of the party you want to trade with: ")
+
+    zec_addr = input("Enter the zcash address of "
+                     "the party you want to trade with: ")
     if zec_addr == '':
-        zec_addr = "tmTF7LMLjvEsGdcepWPUsh4vgJNrKMWwEyc" # regtest
+        zec_addr = "tmTF7LMLjvEsGdcepWPUsh4vgJNrKMWwEyc"  # regtest
     print(zec_addr)
+
     addresses = {'bitcoin': btc_addr, 'zcash': zec_addr}
     return addresses
 
 
-def authorize_buyer_fulfill(sell_p2sh_balance, sell_currency, buy_p2sh_balance, buy_currency):
-    input("The seller's p2sh is funded with {0} {1}, type 'enter' if this is the amount you want to buy in {1}.".format(sell_p2sh_balance, sell_currency))
-    input("You have not send funds to the contract to buy {1} (requested amount: {0}), type 'enter' to allow this program to send the agreed upon funds on your behalf.".format(buy_p2sh_balance, buy_currency))
+def authorize_buyer_fulfill(sell_p2sh_balance, sell_currency,
+                            buy_p2sh_balance, buy_currency):
+    input("The seller's p2sh is funded with {0} {1}, "
+          "type 'enter' if this is the amount you want to buy "
+          "in {1}.".format(sell_p2sh_balance, sell_currency))
+    input("You have not send funds to the contract to buy {1} "
+          "(requested amount: {0}), type 'enter' to allow this program "
+          "to send the agreed upon funds on your behalf.".format(
+            buy_p2sh_balance, buy_currency))
 
 
 def authorize_seller_redeem(buy):
-    input("Buyer funded the contract where you offered to buy {0}, type 'enter' to redeem {1} {0} from {2}.".format(buy.currency, buy.amount, buy.p2sh))
+    input("Buyer funded the contract where you offered to buy {0}, "
+          "type 'enter' to redeem {1} {0} from "
+          "{2}.".format(buy.currency, buy.amount, buy.p2sh))
 
 
 def authorize_buyer_redeem(trade):
-    input("Seller funded the contract where you paid them in {0} to buy {1}, type 'enter' to redeem {2} {1} from {3}.".format(trade.buy.currency, trade.sell.currency, trade.sell.amount, trade.sell.p2sh))
+    input("Seller funded the contract where you paid them in {0} "
+          "to buy {1}, type 'enter' to redeem {2} {1} from "
+          "{3}.".format(trade.buy.currency, trade.sell.currency,
+                        trade.sell.amount, trade.sell.p2sh))

--- a/xcat/utils.py
+++ b/xcat/utils.py
@@ -1,31 +1,42 @@
-import hashlib, json, random, binascii
-import xcat.trades as trades
+import hashlib
+import json
+import random
+import binascii
 import os
+import xcat.trades as trades
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
 
 ############################################
 ########### Data conversion utils ##########
 ############################################
+
+
 def b(string):
     """Convert a string to bytes"""
     return str.encode(string)
+
 
 def x(h):
     """Convert a hex string to bytes"""
     return binascii.unhexlify(h.encode('utf8'))
 
+
 def b2x(b):
     """Convert bytes to a hex string"""
     return binascii.hexlify(b).decode('utf8')
+
 
 def x2s(hexstring):
     """Convert hex to a utf-8 string"""
     return binascii.unhexlify(hexstring).decode('utf-8')
 
+
 def s2x(string):
     """Convert a utf-8 string to hex"""
     return b2x(b(string))
+
 
 def hex2dict(hexstr):
     jsonstr = x2s(hexstr)
@@ -33,47 +44,58 @@ def hex2dict(hexstr):
     print(jsonstr)
     return json.loads(jsonstr)
 
+
 def jsonformat(trade):
     return {
-    'sell': trade.sell.__dict__,
-    'buy': trade.buyContract.__dict__
+        'sell': trade.sell.__dict__,
+        'buy': trade.buyContract.__dict__
     }
+
 
 ############################################
 ########### Preimage utils #################
 ############################################
 
+
 def generate_password():
-    s = "1234567890abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    s = ("1234567890abcdefghijklmnopqrstuvwxyz"
+         "01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ")
     passlen = 32
-    p =  "".join(random.sample(s,passlen))
+    p = "".join(random.sample(s, passlen))
     return p
+
 
 def sha256(secret):
     preimage = secret.encode('utf8')
     h = hashlib.sha256(preimage).digest()
     return h
 
+
 ############################################
 ######## Error handling for CLI ############
 ############################################
+
 
 def throw(err):
     print(err)
     exit()
 
+
 #############################################
 #########  xcat.json temp file  #############
 #############################################
+
 
 tmp_dir = os.path.join(ROOT_DIR, '.tmp')
 if not os.path.exists(tmp_dir):
     os.makedirs(tmp_dir)
 xcatjson = os.path.join(tmp_dir, 'xcat.json')
 
+
 def save_trade(trade):
     with open(xcatjson, 'w+') as outfile:
         json.dump(trade, outfile)
+
 
 def get_trade():
     with open(xcatjson) as data_file:
@@ -83,6 +105,7 @@ def get_trade():
         trade = trades.Trade(sell, buy, commitment=xcatdb['commitment'])
         return trade
 
+
 def erase_trade():
     try:
         with open(xcatjson, 'w') as outfile:
@@ -90,14 +113,16 @@ def erase_trade():
     except:
         pass
 
+
 def save(trade):
     # print("Saving trade")
     trade = {
-    'sell': trade.sell.__dict__,
-    'buy': trade.buy.__dict__,
-    'commitment': trade.commitment
+        'sell': trade.sell.__dict__,
+        'buy': trade.buy.__dict__,
+        'commitment': trade.commitment
     }
     save_trade(trade)
+
 
 # Remove tmp files when trade is complete
 def cleanup(tradeid):

--- a/xcat/xcatconf.py
+++ b/xcat/xcatconf.py
@@ -2,12 +2,12 @@
 ADDRS = {
     'regtest': {
         "initiator": {
-            "bitcoin": "mvc56qCEVj6p57xZ5URNC3v7qbatudHQ9b",
-            "zcash": "tmTF7LMLjvEsGdcepWPUsh4vgJNrKMWwEyc"
+            "bitcoin": "moAccTjGt6nRCoLKhVLrDCAkqDt7fnsAgC",
+            "zcash": "tmJBCsE4ZBcgi2LykoUyei5PDT1cQPkFxpf"
         },
         "fulfiller": {
-            "bitcoin": "moRt56gJQGDNK46Y6fYy2HbooKnQXrTGDN",
-            "zcash": "tmK3rGzHDqa78MCwEicx9VcY9ZWX9gCF2nd"
+            "bitcoin": "mxdJ47MeEeqrBDjHj7SrSLFoDuSP3G37t5",
+            "zcash": "tmBbe7hWtexP94638H1QUD9Z92BM4ZiXXgA"
         },
         "amounts": {'buy': {'currency': 'zcash', 'amount': 0.02}, 'sell': {'currency': 'bitcoin', 'amount': 0.01}}
     },

--- a/xcat/xcatconf.py
+++ b/xcat/xcatconf.py
@@ -2,12 +2,12 @@
 ADDRS = {
     'regtest': {
         "initiator": {
-            "bitcoin": "moAccTjGt6nRCoLKhVLrDCAkqDt7fnsAgC",
-            "zcash": "tmJBCsE4ZBcgi2LykoUyei5PDT1cQPkFxpf"
+            "bitcoin": "mvc56qCEVj6p57xZ5URNC3v7qbatudHQ9b",
+            "zcash": "tmTF7LMLjvEsGdcepWPUsh4vgJNrKMWwEyc"
         },
         "fulfiller": {
-            "bitcoin": "mxdJ47MeEeqrBDjHj7SrSLFoDuSP3G37t5",
-            "zcash": "tmBbe7hWtexP94638H1QUD9Z92BM4ZiXXgA"
+            "bitcoin": "moRt56gJQGDNK46Y6fYy2HbooKnQXrTGDN",
+            "zcash": "tmK3rGzHDqa78MCwEicx9VcY9ZWX9gCF2nd"
         },
         "amounts": {'buy': {'currency': 'zcash', 'amount': 0.02}, 'sell': {'currency': 'bitcoin', 'amount': 0.01}}
     },
@@ -17,11 +17,9 @@ ADDRS = {
             "zcash": "tmTF7LMLjvEsGdcepWPUsh4vgJNrKMWwEyc"
         },
         "fulfiller": {
-            "bitcoin": "mn2boR7rYq9DaAWWrVN5MazHKFyf7UhdyU",
-            "zcash": "tmErB22A1G74aq32aAh5AoqgQSJsAAAdT2p"
+            "bitcoin": "mm2smEJjRN4xoijEfpb5XvYd8e3EYWezom",
+            "zcash": "tmPwPdceaJAHQn7UiRCVnJ5tXBXHVqWMkis"
         },
         "amounts": {'buy': {'currency': 'zcash', 'amount': 0.02}, 'sell': {'currency': 'bitcoin', 'amount': 0.01}}
     }
 }
-
-NETWORK = 'testnet'

--- a/xcat/zcashRPC.py
+++ b/xcat/zcashRPC.py
@@ -26,6 +26,11 @@ FEE = 0.001 * COIN
 
 class zcashProxy():
     def __init__(self, network='regtest', timeout=900):
+        if network not in ['testnet', 'mainnet', 'regtest']:
+            raise ValueError('Allowed networks are regtest, testnet, mainnet.')
+        if not isinstance(timeout, int) or timeout < 1:
+            raise ValueError('Timeout should be a positive integer.')
+
         self.network = network
         self.timeout = timeout
 

--- a/xcat/zcashRPC.py
+++ b/xcat/zcashRPC.py
@@ -21,7 +21,7 @@ if sys.version_info.major < 3:
     sys.stderr.write('Sorry, Python 3.x required by this example.\n')
     sys.exit(1)
 
-FEE = 0.001*COIN
+FEE = 0.001 * COIN
 
 
 class zcashProxy():
@@ -80,7 +80,7 @@ class zcashProxy():
                 'locktime': locktime}
 
     def fund_htlc(self, p2sh, amount):
-        send_amount = float(amount)*COIN
+        send_amount = float(amount) * COIN
         # Import addr at same time as you fund
         self.zcashd.importaddress(p2sh, "", False)
         fund_txid = self.zcashd.sendtoaddress(p2sh, send_amount)
@@ -92,13 +92,13 @@ class zcashProxy():
         self.zcashd.importaddress(p2sh, "", False)
         # Get amount in address
         amount = self.zcashd.getreceivedbyaddress(p2sh, 0)
-        amount = amount/COIN
+        amount = amount / COIN
         return amount
 
     def get_fund_status(self, p2sh):
         self.zcashd.importaddress(p2sh, "", False)
         amount = self.zcashd.getreceivedbyaddress(p2sh, 0)
-        amount = amount/COIN
+        amount = amount / COIN
         print("Amount in zcash p2sh: ", amount, p2sh)
         if amount > 0:
             return 'funded'


### PR DESCRIPTION
~~Placeholder PR for ongoing work.~~

- [X] Refactor Protocol
- [X] Start linting with flake8
- [X] Layout and start unit tests
- [X] Write more unit tests
- [x] More linting!
- [X] Reincorporate old integration tests
~~- [ ] Write regtest scripts~~
- [x] setup tox or similar testrunner
- [x] Refactor DB to avoid instantiating on import
- [X] Figure out if existing tests a) work, b) belong as e2e tests
~~- [ ] Remove side effects from existing tests~~


**Notes:**
~~It's hard to tell if I've broken anything, as I'm still struggling with the regtest setups for bitcoind and zcashd. The vast majority of changes are style, but with the Protocol refactor in particular it's possible I missed something.~~ Updated in next comment.

I refactored Protocol to be an object. This prevents it from instantiating RPC objects on import, and makes testing much easier.  You no longer have to run bitcoind and zcashd with appropriate conf files to run unit tests.

~~I've removed the existing tests from test_cli.py. They should go back in in the future, as integration and end-to-end tests, once there's a good solution for spinning up environments.~~ Moved my tests to a new unit test folder and brought back the original `test_cli.py`.

I implemented unit tests for and added an error case to the `find_role` function in cli.py, because it was easy. Harder tests soon. >.>

I've done a significant amount of linting using flake8 (specifically linter-flake8 in Atom) on the files I've touched. Linting notes:

-  wildcards are replaced by package imports, so that the location of a function is explicit. E.g. `utils.save()` instead of `save()`.
- there are a few styled comments in utils.py that I left intact.
- there is a large console output block in cli that should either be broken up, or added to an ignore list.